### PR TITLE
PYTHON-5898 Reduce pool checkout lock overhead and stop mutating TopologyDescription during selection

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -27,13 +27,8 @@ PyMongo 4.18 brings a number of changes including:
   buffer.
 - Fixed :func:`bson.json_util.loads` to reject ``$timestamp`` values containing
   fields other than ``t`` and ``i``.
-- Fixed :attr:`~pymongo.topology_description.TopologyDescription.candidate_servers`
-  to once again return all known servers, matching its behavior before
-  PyMongo 4.16.0. Deprioritization is now applied per server-selection call
-  instead of being cached on the (shared, immutable)
-  :class:`~pymongo.topology_description.TopologyDescription`. This fixes
-  ``client.primary`` raising ``IndexError``, and ``client.secondaries`` and
-  ``client.arbiters`` returning stale results, after a retryable operation
+- Fixed ``client.primary`` raising ``IndexError``, and ``client.secondaries``
+  and ``client.arbiters`` returning stale results, after a retryable operation
   deprioritized the primary.
 - Fixed a leak where every failed connection checkout permanently
   incremented a pool's ``operation_count``, biasing server selection among

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -30,6 +30,11 @@ PyMongo 4.18 brings a number of changes including:
 - Fixed ``client.primary`` raising ``IndexError``, and ``client.secondaries``
   and ``client.arbiters`` returning stale results, after a retryable operation
   deprioritized the primary.
+- Removed ``TopologyDescription.candidate_servers``, added in PyMongo 4.16.0.
+  Its value depended on which server-selection call happened to run last, so it
+  could not be relied on. Use
+  :meth:`~pymongo.topology_description.TopologyDescription.server_descriptions`
+  instead.
 - Fixed a leak where every failed connection checkout permanently
   incremented a pool's ``operation_count``, biasing server selection among
   mongoses toward the affected server.

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -33,7 +33,7 @@ PyMongo 4.18 brings a number of changes including:
 - Removed ``TopologyDescription.candidate_servers``, added in PyMongo 4.16.0.
   Its value depended on which server-selection call happened to run last, so it
   could not be relied on. Use
-  :meth:`~pymongo.topology_description.TopologyDescription.server_descriptions`
+  :attr:`~pymongo.topology_description.TopologyDescription.known_servers`
   instead.
 - Fixed a leak where every failed connection checkout permanently
   incremented a pool's ``operation_count``, biasing server selection among

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -27,6 +27,19 @@ PyMongo 4.18 brings a number of changes including:
   buffer.
 - Fixed :func:`bson.json_util.loads` to reject ``$timestamp`` values containing
   fields other than ``t`` and ``i``.
+- Fixed :attr:`~pymongo.topology_description.TopologyDescription.candidate_servers`
+  to once again return all known servers, matching its behavior before
+  PyMongo 4.16.0. Deprioritization is now applied per server-selection call
+  instead of being cached on the (shared, immutable)
+  :class:`~pymongo.topology_description.TopologyDescription`. This fixes
+  ``client.primary`` raising ``IndexError``, and ``client.secondaries`` and
+  ``client.arbiters`` returning stale results, after a retryable operation
+  deprioritized the primary.
+- Fixed a leak where every failed connection checkout permanently
+  incremented a pool's ``operation_count``, biasing server selection among
+  mongoses toward the affected server.
+- Reduced the number of lock acquisitions on the connection checkout fast
+  path.
 
 Changes in Version 4.17.0 (2026/04/20)
 --------------------------------------

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -30,14 +30,18 @@ PyMongo 4.18 brings a number of changes including:
 - Fixed ``client.primary`` raising ``IndexError``, and ``client.secondaries``
   and ``client.arbiters`` returning stale results, after a retryable operation
   deprioritized the primary.
-- Removed ``TopologyDescription.candidate_servers``, added in PyMongo 4.16.0.
-  Its value depended on which server-selection call happened to run last, so it
-  could not be relied on. Use
+- **Breaking change**: removed the public ``TopologyDescription.candidate_servers``
+  attribute, which was added in PyMongo 4.16.0 and appeared in the 4.16 and
+  4.17 API documentation. Its value depended on which server-selection call
+  happened to run last, so it could not be relied on. Any code reading it must
+  be updated to use
   :attr:`~pymongo.topology_description.TopologyDescription.known_servers`
   instead.
-- Fixed a leak where every failed connection checkout permanently
-  incremented a pool's ``operation_count``, biasing server selection among
-  mongoses toward the affected server.
+- Fixed a leak where every failed connection checkout permanently incremented
+  a pool's ``operation_count``. Because nothing short of a fork reset that
+  counter, a mongos that suffered a burst of checkout failures looked
+  permanently busier than its peers and was progressively avoided by server
+  selection for the remaining life of the client.
 - Reduced the number of lock acquisitions on the connection checkout fast
   path.
 

--- a/pymongo/asynchronous/pool.py
+++ b/pymongo/asynchronous/pool.py
@@ -1026,23 +1026,21 @@ class Pool:
             async with self.lock:
                 self.operation_count += 1
                 op_count_incremented = True
-                # Emission is deferred to the outer `except` below (which
-                # runs for any exception raised inside this `try`, unlike
-                # the pre-refactor code where this check lived outside the
-                # `try`); emitting here too would double-emit the event.
+                # The outer `except` below emits for any exception raised in
+                # this `try`, so emitting here too would double-emit.
                 self._raise_if_not_ready(checkout_started_time, emit_event=False)
                 if self.requests < self.max_pool_size:
                     # Fast path: a slot is immediately available, so do all
-                    # of the counter bookkeeping in this single critical
-                    # section instead of taking the lock multiple times.
+                    # of the counter bookkeeping in this one critical section
+                    # and keep the checkout to a single lock acquisition.
                     self.requests += 1
                     requests_incremented = True
                     self.active_sockets += 1
                     active_sockets_incremented = True
 
             if not requests_incremented:
-                # Slow path: no slot was free. Fall back to waiting on the
-                # requests semaphore, exactly as before.
+                # Slow path: no slot was free, so wait on the requests
+                # semaphore for one to be released.
                 async with self.size_cond:
                     self._raise_if_not_ready(checkout_started_time, emit_event=False)
                     while not (self.requests < self.max_pool_size):

--- a/pymongo/asynchronous/pool.py
+++ b/pymongo/asynchronous/pool.py
@@ -1007,9 +1007,6 @@ class Pool:
                 "Attempted to check out a connection from closed connection pool"
             )
 
-        async with self.lock:
-            self.operation_count += 1
-
         # Get a free socket or create one.
         if _csot.get_timeout():
             deadline = _csot.get_deadline()
@@ -1018,28 +1015,50 @@ class Pool:
         else:
             deadline = None
 
-        async with self.size_cond:
-            self._raise_if_not_ready(checkout_started_time, emit_event=True)
-            while not (self.requests < self.max_pool_size):
-                timeout = deadline - time.monotonic() if deadline else None
-                if not await _async_cond_wait(self.size_cond, timeout):
-                    # Timed out, notify the next thread to ensure a
-                    # timeout doesn't consume the condition.
-                    if self.requests < self.max_pool_size:
-                        self.size_cond.notify()
-                    self._raise_wait_queue_timeout(checkout_started_time)
-                self._raise_if_not_ready(checkout_started_time, emit_event=True)
-            self.requests += 1
-
-        # We've now acquired the semaphore and must release it on error.
         conn = None
-        incremented = False
+        op_count_incremented = False
+        requests_incremented = False
+        active_sockets_incremented = False
         emitted_event = False
         is_new_conn = False
+
         try:
+            slot_acquired = False
             async with self.lock:
-                self.active_sockets += 1
-                incremented = True
+                self.operation_count += 1
+                op_count_incremented = True
+                self._raise_if_not_ready(checkout_started_time, emit_event=True)
+                if self.requests < self.max_pool_size:
+                    # Fast path: a slot is immediately available, so do all
+                    # of the counter bookkeeping in this single critical
+                    # section instead of taking the lock multiple times.
+                    self.requests += 1
+                    requests_incremented = True
+                    self.active_sockets += 1
+                    active_sockets_incremented = True
+                    slot_acquired = True
+
+            if not slot_acquired:
+                # Slow path: no slot was free. Fall back to waiting on the
+                # requests semaphore, exactly as before.
+                async with self.size_cond:
+                    self._raise_if_not_ready(checkout_started_time, emit_event=True)
+                    while not (self.requests < self.max_pool_size):
+                        timeout = deadline - time.monotonic() if deadline else None
+                        if not await _async_cond_wait(self.size_cond, timeout):
+                            # Timed out, notify the next thread to ensure a
+                            # timeout doesn't consume the condition.
+                            if self.requests < self.max_pool_size:
+                                self.size_cond.notify()
+                            self._raise_wait_queue_timeout(checkout_started_time)
+                        self._raise_if_not_ready(checkout_started_time, emit_event=True)
+                    self.requests += 1
+                    requests_incremented = True
+
+                async with self.lock:
+                    self.active_sockets += 1
+                    active_sockets_incremented = True
+
             while conn is None:
                 # CMAP: we MUST wait for either maxConnecting OR for a socket
                 # to be checked back into the pool.
@@ -1084,11 +1103,16 @@ class Pool:
             if conn:
                 # We checked out a socket but authentication failed.
                 await conn.close_conn(ConnectionClosedReason.ERROR)
-            async with self.size_cond:
-                self.requests -= 1
-                if incremented:
-                    self.active_sockets -= 1
-                self.size_cond.notify()
+            if requests_incremented or active_sockets_incremented:
+                async with self.size_cond:
+                    if requests_incremented:
+                        self.requests -= 1
+                    if active_sockets_incremented:
+                        self.active_sockets -= 1
+                    self.size_cond.notify()
+            if op_count_incremented:
+                async with self.lock:
+                    self.operation_count -= 1
 
             if not emitted_event:
                 self._telemetry.checkout_failed(

--- a/pymongo/asynchronous/pool.py
+++ b/pymongo/asynchronous/pool.py
@@ -1017,7 +1017,11 @@ class Pool:
 
         conn = None
         op_count_incremented = False
-        slot_acquired = False
+        # Each flag is set immediately after its own increment, with no
+        # statement in between, so an interrupt cannot leave a counter
+        # incremented but unrecorded.
+        requests_incremented = False
+        active_sockets_incremented = False
         # Invariant: any site inside the `try` below that emits a checkout
         # failed event must set this so the outer handler does not re-emit.
         emitted_event = False
@@ -1035,10 +1039,11 @@ class Pool:
                     # of the counter bookkeeping in this one critical section
                     # and keep the checkout to a single lock acquisition.
                     self.requests += 1
+                    requests_incremented = True
                     self.active_sockets += 1
-                    slot_acquired = True
+                    active_sockets_incremented = True
 
-            if not slot_acquired:
+            if not requests_incremented:
                 # Slow path: no slot was free, so wait on the requests
                 # semaphore for one to be released.
                 async with self.size_cond:
@@ -1058,8 +1063,9 @@ class Pool:
                         self._raise_if_not_ready(checkout_started_time, emit_event=True)
                         emitted_event = False
                     self.requests += 1
+                    requests_incremented = True
                     self.active_sockets += 1
-                    slot_acquired = True
+                    active_sockets_incremented = True
 
             while conn is None:
                 # CMAP: we MUST wait for either maxConnecting OR for a socket
@@ -1108,9 +1114,11 @@ class Pool:
             if op_count_incremented:
                 async with self.size_cond:
                     self.operation_count -= 1
-                    if slot_acquired:
-                        self.requests -= 1
+                    if active_sockets_incremented:
                         self.active_sockets -= 1
+                    if requests_incremented:
+                        # Notify last, so a waiter wakes to consistent counters.
+                        self.requests -= 1
                         self.size_cond.notify()
 
             if not emitted_event:

--- a/pymongo/asynchronous/pool.py
+++ b/pymongo/asynchronous/pool.py
@@ -1017,8 +1017,9 @@ class Pool:
 
         conn = None
         op_count_incremented = False
-        requests_incremented = False
-        active_sockets_incremented = False
+        slot_acquired = False
+        # Invariant: any site inside the `try` below that emits a checkout
+        # failed event must set this so the outer handler does not re-emit.
         emitted_event = False
         is_new_conn = False
 
@@ -1026,23 +1027,24 @@ class Pool:
             async with self.lock:
                 self.operation_count += 1
                 op_count_incremented = True
-                # The outer `except` below emits for any exception raised in
-                # this `try`, so emitting here too would double-emit.
-                self._raise_if_not_ready(checkout_started_time, emit_event=False)
+                emitted_event = True
+                self._raise_if_not_ready(checkout_started_time, emit_event=True)
+                emitted_event = False
                 if self.requests < self.max_pool_size:
                     # Fast path: a slot is immediately available, so do all
                     # of the counter bookkeeping in this one critical section
                     # and keep the checkout to a single lock acquisition.
                     self.requests += 1
-                    requests_incremented = True
                     self.active_sockets += 1
-                    active_sockets_incremented = True
+                    slot_acquired = True
 
-            if not requests_incremented:
+            if not slot_acquired:
                 # Slow path: no slot was free, so wait on the requests
                 # semaphore for one to be released.
                 async with self.size_cond:
-                    self._raise_if_not_ready(checkout_started_time, emit_event=False)
+                    emitted_event = True
+                    self._raise_if_not_ready(checkout_started_time, emit_event=True)
+                    emitted_event = False
                     while not (self.requests < self.max_pool_size):
                         timeout = deadline - time.monotonic() if deadline else None
                         if not await _async_cond_wait(self.size_cond, timeout):
@@ -1052,13 +1054,12 @@ class Pool:
                                 self.size_cond.notify()
                             emitted_event = True
                             self._raise_wait_queue_timeout(checkout_started_time)
-                        self._raise_if_not_ready(checkout_started_time, emit_event=False)
+                        emitted_event = True
+                        self._raise_if_not_ready(checkout_started_time, emit_event=True)
+                        emitted_event = False
                     self.requests += 1
-                    requests_incremented = True
-
-                async with self.lock:
                     self.active_sockets += 1
-                    active_sockets_incremented = True
+                    slot_acquired = True
 
             while conn is None:
                 # CMAP: we MUST wait for either maxConnecting OR for a socket
@@ -1104,15 +1105,12 @@ class Pool:
             if conn:
                 # We checked out a socket but authentication failed.
                 await conn.close_conn(ConnectionClosedReason.ERROR)
-            if requests_incremented or active_sockets_incremented or op_count_incremented:
+            if op_count_incremented:
                 async with self.size_cond:
-                    if requests_incremented:
+                    self.operation_count -= 1
+                    if slot_acquired:
                         self.requests -= 1
-                    if active_sockets_incremented:
                         self.active_sockets -= 1
-                    if op_count_incremented:
-                        self.operation_count -= 1
-                    if requests_incremented or active_sockets_incremented:
                         self.size_cond.notify()
 
             if not emitted_event:

--- a/pymongo/asynchronous/pool.py
+++ b/pymongo/asynchronous/pool.py
@@ -1018,8 +1018,10 @@ class Pool:
         conn = None
         op_count_incremented = False
         # Each flag is set immediately after its own increment, with no
-        # statement in between, so an interrupt cannot leave a counter
-        # incremented but unrecorded.
+        # statement in between, which narrows the window in which an interrupt
+        # could leave a counter incremented but unrecorded to a single
+        # statement boundary. It does not close the window entirely: the
+        # increment and the flag assignment are still separate statements.
         requests_incremented = False
         active_sockets_incremented = False
         # Invariant: any site inside the `try` below that emits a checkout
@@ -1044,8 +1046,10 @@ class Pool:
                     active_sockets_incremented = True
 
             if not requests_incremented:
-                # Slow path: no slot was free, so wait on the requests
-                # semaphore for one to be released.
+                # Slow path: no slot was free under the pool mutex. Re-check
+                # under size_cond -- a slot may have been released in the
+                # meantime, in which case the loop below never waits -- and
+                # otherwise wait for one to be released.
                 async with self.size_cond:
                     emitted_event = True
                     self._raise_if_not_ready(checkout_started_time, emit_event=True)
@@ -1117,8 +1121,10 @@ class Pool:
                     if active_sockets_incremented:
                         self.active_sockets -= 1
                     if requests_incremented:
-                        # Notify last, so a waiter wakes to consistent counters.
                         self.requests -= 1
+                        # Notify only when a slot was actually released;
+                        # otherwise there is nothing for a blocked checkout to
+                        # wake up for.
                         self.size_cond.notify()
 
             if not emitted_event:

--- a/pymongo/asynchronous/pool.py
+++ b/pymongo/asynchronous/pool.py
@@ -1023,11 +1023,14 @@ class Pool:
         is_new_conn = False
 
         try:
-            slot_acquired = False
             async with self.lock:
                 self.operation_count += 1
                 op_count_incremented = True
-                self._raise_if_not_ready(checkout_started_time, emit_event=True)
+                # Emission is deferred to the outer `except` below (which
+                # runs for any exception raised inside this `try`, unlike
+                # the pre-refactor code where this check lived outside the
+                # `try`); emitting here too would double-emit the event.
+                self._raise_if_not_ready(checkout_started_time, emit_event=False)
                 if self.requests < self.max_pool_size:
                     # Fast path: a slot is immediately available, so do all
                     # of the counter bookkeeping in this single critical
@@ -1036,13 +1039,12 @@ class Pool:
                     requests_incremented = True
                     self.active_sockets += 1
                     active_sockets_incremented = True
-                    slot_acquired = True
 
-            if not slot_acquired:
+            if not requests_incremented:
                 # Slow path: no slot was free. Fall back to waiting on the
                 # requests semaphore, exactly as before.
                 async with self.size_cond:
-                    self._raise_if_not_ready(checkout_started_time, emit_event=True)
+                    self._raise_if_not_ready(checkout_started_time, emit_event=False)
                     while not (self.requests < self.max_pool_size):
                         timeout = deadline - time.monotonic() if deadline else None
                         if not await _async_cond_wait(self.size_cond, timeout):
@@ -1050,8 +1052,9 @@ class Pool:
                             # timeout doesn't consume the condition.
                             if self.requests < self.max_pool_size:
                                 self.size_cond.notify()
+                            emitted_event = True
                             self._raise_wait_queue_timeout(checkout_started_time)
-                        self._raise_if_not_ready(checkout_started_time, emit_event=True)
+                        self._raise_if_not_ready(checkout_started_time, emit_event=False)
                     self.requests += 1
                     requests_incremented = True
 
@@ -1103,16 +1106,16 @@ class Pool:
             if conn:
                 # We checked out a socket but authentication failed.
                 await conn.close_conn(ConnectionClosedReason.ERROR)
-            if requests_incremented or active_sockets_incremented:
+            if requests_incremented or active_sockets_incremented or op_count_incremented:
                 async with self.size_cond:
                     if requests_incremented:
                         self.requests -= 1
                     if active_sockets_incremented:
                         self.active_sockets -= 1
-                    self.size_cond.notify()
-            if op_count_incremented:
-                async with self.lock:
-                    self.operation_count -= 1
+                    if op_count_incremented:
+                        self.operation_count -= 1
+                    if requests_incremented or active_sockets_incremented:
+                        self.size_cond.notify()
 
             if not emitted_event:
                 self._telemetry.checkout_failed(

--- a/pymongo/server_selectors.py
+++ b/pymongo/server_selectors.py
@@ -35,8 +35,21 @@ class Selection:
     """Input or output of a server selector function."""
 
     @classmethod
-    def from_topology_description(cls, topology_description: TopologyDescription) -> Selection:
-        candidate_servers = topology_description.candidate_servers
+    def from_topology_description(
+        cls,
+        topology_description: TopologyDescription,
+        candidate_servers: Optional[list[ServerDescription]] = None,
+    ) -> Selection:
+        """Build a Selection from a TopologyDescription.
+
+        :param topology_description: the TopologyDescription to select from.
+        :param candidate_servers: the servers eligible for selection. Defaults
+            to ``topology_description.candidate_servers``. Server selection
+            passes its own (per-call, deprioritization-filtered) list here so
+            that no state has to be cached on the TopologyDescription.
+        """
+        if candidate_servers is None:
+            candidate_servers = topology_description.candidate_servers
         primary = None
         for sd in candidate_servers:
             if sd.server_type == SERVER_TYPE.RSPrimary:
@@ -45,7 +58,7 @@ class Selection:
 
         return Selection(
             topology_description,
-            topology_description.candidate_servers,
+            candidate_servers,
             topology_description.common_wire_version,
             primary,
         )

--- a/pymongo/server_selectors.py
+++ b/pymongo/server_selectors.py
@@ -44,12 +44,12 @@ class Selection:
 
         :param topology_description: the TopologyDescription to select from.
         :param candidate_servers: the servers eligible for selection. Defaults
-            to ``topology_description.candidate_servers``. Server selection
-            passes its own (per-call, deprioritization-filtered) list here so
-            that no state has to be cached on the TopologyDescription.
+            to all known servers. Server selection passes its own (per-call,
+            deprioritization-filtered) list here so that no state has to be
+            cached on the TopologyDescription.
         """
         if candidate_servers is None:
-            candidate_servers = topology_description.candidate_servers
+            candidate_servers = topology_description.known_servers
         primary = None
         for sd in candidate_servers:
             if sd.server_type == SERVER_TYPE.RSPrimary:

--- a/pymongo/synchronous/pool.py
+++ b/pymongo/synchronous/pool.py
@@ -1013,8 +1013,9 @@ class Pool:
 
         conn = None
         op_count_incremented = False
-        requests_incremented = False
-        active_sockets_incremented = False
+        slot_acquired = False
+        # Invariant: any site inside the `try` below that emits a checkout
+        # failed event must set this so the outer handler does not re-emit.
         emitted_event = False
         is_new_conn = False
 
@@ -1022,23 +1023,24 @@ class Pool:
             with self.lock:
                 self.operation_count += 1
                 op_count_incremented = True
-                # The outer `except` below emits for any exception raised in
-                # this `try`, so emitting here too would double-emit.
-                self._raise_if_not_ready(checkout_started_time, emit_event=False)
+                emitted_event = True
+                self._raise_if_not_ready(checkout_started_time, emit_event=True)
+                emitted_event = False
                 if self.requests < self.max_pool_size:
                     # Fast path: a slot is immediately available, so do all
                     # of the counter bookkeeping in this one critical section
                     # and keep the checkout to a single lock acquisition.
                     self.requests += 1
-                    requests_incremented = True
                     self.active_sockets += 1
-                    active_sockets_incremented = True
+                    slot_acquired = True
 
-            if not requests_incremented:
+            if not slot_acquired:
                 # Slow path: no slot was free, so wait on the requests
                 # semaphore for one to be released.
                 with self.size_cond:
-                    self._raise_if_not_ready(checkout_started_time, emit_event=False)
+                    emitted_event = True
+                    self._raise_if_not_ready(checkout_started_time, emit_event=True)
+                    emitted_event = False
                     while not (self.requests < self.max_pool_size):
                         timeout = deadline - time.monotonic() if deadline else None
                         if not _cond_wait(self.size_cond, timeout):
@@ -1048,13 +1050,12 @@ class Pool:
                                 self.size_cond.notify()
                             emitted_event = True
                             self._raise_wait_queue_timeout(checkout_started_time)
-                        self._raise_if_not_ready(checkout_started_time, emit_event=False)
+                        emitted_event = True
+                        self._raise_if_not_ready(checkout_started_time, emit_event=True)
+                        emitted_event = False
                     self.requests += 1
-                    requests_incremented = True
-
-                with self.lock:
                     self.active_sockets += 1
-                    active_sockets_incremented = True
+                    slot_acquired = True
 
             while conn is None:
                 # CMAP: we MUST wait for either maxConnecting OR for a socket
@@ -1100,15 +1101,12 @@ class Pool:
             if conn:
                 # We checked out a socket but authentication failed.
                 conn.close_conn(ConnectionClosedReason.ERROR)
-            if requests_incremented or active_sockets_incremented or op_count_incremented:
+            if op_count_incremented:
                 with self.size_cond:
-                    if requests_incremented:
+                    self.operation_count -= 1
+                    if slot_acquired:
                         self.requests -= 1
-                    if active_sockets_incremented:
                         self.active_sockets -= 1
-                    if op_count_incremented:
-                        self.operation_count -= 1
-                    if requests_incremented or active_sockets_incremented:
                         self.size_cond.notify()
 
             if not emitted_event:

--- a/pymongo/synchronous/pool.py
+++ b/pymongo/synchronous/pool.py
@@ -1014,8 +1014,10 @@ class Pool:
         conn = None
         op_count_incremented = False
         # Each flag is set immediately after its own increment, with no
-        # statement in between, so an interrupt cannot leave a counter
-        # incremented but unrecorded.
+        # statement in between, which narrows the window in which an interrupt
+        # could leave a counter incremented but unrecorded to a single
+        # statement boundary. It does not close the window entirely: the
+        # increment and the flag assignment are still separate statements.
         requests_incremented = False
         active_sockets_incremented = False
         # Invariant: any site inside the `try` below that emits a checkout
@@ -1040,8 +1042,10 @@ class Pool:
                     active_sockets_incremented = True
 
             if not requests_incremented:
-                # Slow path: no slot was free, so wait on the requests
-                # semaphore for one to be released.
+                # Slow path: no slot was free under the pool mutex. Re-check
+                # under size_cond -- a slot may have been released in the
+                # meantime, in which case the loop below never waits -- and
+                # otherwise wait for one to be released.
                 with self.size_cond:
                     emitted_event = True
                     self._raise_if_not_ready(checkout_started_time, emit_event=True)
@@ -1113,8 +1117,10 @@ class Pool:
                     if active_sockets_incremented:
                         self.active_sockets -= 1
                     if requests_incremented:
-                        # Notify last, so a witer wakes to consistent counters.
                         self.requests -= 1
+                        # Notify only when a slot was actually released;
+                        # otherwise there is nothing for a blocked checkout to
+                        # wake up for.
                         self.size_cond.notify()
 
             if not emitted_event:

--- a/pymongo/synchronous/pool.py
+++ b/pymongo/synchronous/pool.py
@@ -1013,7 +1013,11 @@ class Pool:
 
         conn = None
         op_count_incremented = False
-        slot_acquired = False
+        # Each flag is set immediately after its own increment, with no
+        # statement in between, so an interrupt cannot leave a counter
+        # incremented but unrecorded.
+        requests_incremented = False
+        active_sockets_incremented = False
         # Invariant: any site inside the `try` below that emits a checkout
         # failed event must set this so the outer handler does not re-emit.
         emitted_event = False
@@ -1031,10 +1035,11 @@ class Pool:
                     # of the counter bookkeeping in this one critical section
                     # and keep the checkout to a single lock acquisition.
                     self.requests += 1
+                    requests_incremented = True
                     self.active_sockets += 1
-                    slot_acquired = True
+                    active_sockets_incremented = True
 
-            if not slot_acquired:
+            if not requests_incremented:
                 # Slow path: no slot was free, so wait on the requests
                 # semaphore for one to be released.
                 with self.size_cond:
@@ -1054,8 +1059,9 @@ class Pool:
                         self._raise_if_not_ready(checkout_started_time, emit_event=True)
                         emitted_event = False
                     self.requests += 1
+                    requests_incremented = True
                     self.active_sockets += 1
-                    slot_acquired = True
+                    active_sockets_incremented = True
 
             while conn is None:
                 # CMAP: we MUST wait for either maxConnecting OR for a socket
@@ -1104,9 +1110,11 @@ class Pool:
             if op_count_incremented:
                 with self.size_cond:
                     self.operation_count -= 1
-                    if slot_acquired:
-                        self.requests -= 1
+                    if active_sockets_incremented:
                         self.active_sockets -= 1
+                    if requests_incremented:
+                        # Notify last, so a witer wakes to consistent counters.
+                        self.requests -= 1
                         self.size_cond.notify()
 
             if not emitted_event:

--- a/pymongo/synchronous/pool.py
+++ b/pymongo/synchronous/pool.py
@@ -1019,11 +1019,14 @@ class Pool:
         is_new_conn = False
 
         try:
-            slot_acquired = False
             with self.lock:
                 self.operation_count += 1
                 op_count_incremented = True
-                self._raise_if_not_ready(checkout_started_time, emit_event=True)
+                # Emission is deferred to the outer `except` below (which
+                # runs for any exception raised inside this `try`, unlike
+                # the pre-refactor code where this check lived outside the
+                # `try`); emitting here too would double-emit the event.
+                self._raise_if_not_ready(checkout_started_time, emit_event=False)
                 if self.requests < self.max_pool_size:
                     # Fast path: a slot is immediately available, so do all
                     # of the counter bookkeeping in this single critical
@@ -1032,13 +1035,12 @@ class Pool:
                     requests_incremented = True
                     self.active_sockets += 1
                     active_sockets_incremented = True
-                    slot_acquired = True
 
-            if not slot_acquired:
+            if not requests_incremented:
                 # Slow path: no slot was free. Fall back to waiting on the
                 # requests semaphore, exactly as before.
                 with self.size_cond:
-                    self._raise_if_not_ready(checkout_started_time, emit_event=True)
+                    self._raise_if_not_ready(checkout_started_time, emit_event=False)
                     while not (self.requests < self.max_pool_size):
                         timeout = deadline - time.monotonic() if deadline else None
                         if not _cond_wait(self.size_cond, timeout):
@@ -1046,8 +1048,9 @@ class Pool:
                             # timeout doesn't consume the condition.
                             if self.requests < self.max_pool_size:
                                 self.size_cond.notify()
+                            emitted_event = True
                             self._raise_wait_queue_timeout(checkout_started_time)
-                        self._raise_if_not_ready(checkout_started_time, emit_event=True)
+                        self._raise_if_not_ready(checkout_started_time, emit_event=False)
                     self.requests += 1
                     requests_incremented = True
 
@@ -1099,16 +1102,16 @@ class Pool:
             if conn:
                 # We checked out a socket but authentication failed.
                 conn.close_conn(ConnectionClosedReason.ERROR)
-            if requests_incremented or active_sockets_incremented:
+            if requests_incremented or active_sockets_incremented or op_count_incremented:
                 with self.size_cond:
                     if requests_incremented:
                         self.requests -= 1
                     if active_sockets_incremented:
                         self.active_sockets -= 1
-                    self.size_cond.notify()
-            if op_count_incremented:
-                with self.lock:
-                    self.operation_count -= 1
+                    if op_count_incremented:
+                        self.operation_count -= 1
+                    if requests_incremented or active_sockets_incremented:
+                        self.size_cond.notify()
 
             if not emitted_event:
                 self._telemetry.checkout_failed(

--- a/pymongo/synchronous/pool.py
+++ b/pymongo/synchronous/pool.py
@@ -1003,9 +1003,6 @@ class Pool:
                 "Attempted to check out a connection from closed connection pool"
             )
 
-        with self.lock:
-            self.operation_count += 1
-
         # Get a free socket or create one.
         if _csot.get_timeout():
             deadline = _csot.get_deadline()
@@ -1014,28 +1011,50 @@ class Pool:
         else:
             deadline = None
 
-        with self.size_cond:
-            self._raise_if_not_ready(checkout_started_time, emit_event=True)
-            while not (self.requests < self.max_pool_size):
-                timeout = deadline - time.monotonic() if deadline else None
-                if not _cond_wait(self.size_cond, timeout):
-                    # Timed out, notify the next thread to ensure a
-                    # timeout doesn't consume the condition.
-                    if self.requests < self.max_pool_size:
-                        self.size_cond.notify()
-                    self._raise_wait_queue_timeout(checkout_started_time)
-                self._raise_if_not_ready(checkout_started_time, emit_event=True)
-            self.requests += 1
-
-        # We've now acquired the semaphore and must release it on error.
         conn = None
-        incremented = False
+        op_count_incremented = False
+        requests_incremented = False
+        active_sockets_incremented = False
         emitted_event = False
         is_new_conn = False
+
         try:
+            slot_acquired = False
             with self.lock:
-                self.active_sockets += 1
-                incremented = True
+                self.operation_count += 1
+                op_count_incremented = True
+                self._raise_if_not_ready(checkout_started_time, emit_event=True)
+                if self.requests < self.max_pool_size:
+                    # Fast path: a slot is immediately available, so do all
+                    # of the counter bookkeeping in this single critical
+                    # section instead of taking the lock multiple times.
+                    self.requests += 1
+                    requests_incremented = True
+                    self.active_sockets += 1
+                    active_sockets_incremented = True
+                    slot_acquired = True
+
+            if not slot_acquired:
+                # Slow path: no slot was free. Fall back to waiting on the
+                # requests semaphore, exactly as before.
+                with self.size_cond:
+                    self._raise_if_not_ready(checkout_started_time, emit_event=True)
+                    while not (self.requests < self.max_pool_size):
+                        timeout = deadline - time.monotonic() if deadline else None
+                        if not _cond_wait(self.size_cond, timeout):
+                            # Timed out, notify the next thread to ensure a
+                            # timeout doesn't consume the condition.
+                            if self.requests < self.max_pool_size:
+                                self.size_cond.notify()
+                            self._raise_wait_queue_timeout(checkout_started_time)
+                        self._raise_if_not_ready(checkout_started_time, emit_event=True)
+                    self.requests += 1
+                    requests_incremented = True
+
+                with self.lock:
+                    self.active_sockets += 1
+                    active_sockets_incremented = True
+
             while conn is None:
                 # CMAP: we MUST wait for either maxConnecting OR for a socket
                 # to be checked back into the pool.
@@ -1080,11 +1099,16 @@ class Pool:
             if conn:
                 # We checked out a socket but authentication failed.
                 conn.close_conn(ConnectionClosedReason.ERROR)
-            with self.size_cond:
-                self.requests -= 1
-                if incremented:
-                    self.active_sockets -= 1
-                self.size_cond.notify()
+            if requests_incremented or active_sockets_incremented:
+                with self.size_cond:
+                    if requests_incremented:
+                        self.requests -= 1
+                    if active_sockets_incremented:
+                        self.active_sockets -= 1
+                    self.size_cond.notify()
+            if op_count_incremented:
+                with self.lock:
+                    self.operation_count -= 1
 
             if not emitted_event:
                 self._telemetry.checkout_failed(

--- a/pymongo/synchronous/pool.py
+++ b/pymongo/synchronous/pool.py
@@ -1022,23 +1022,21 @@ class Pool:
             with self.lock:
                 self.operation_count += 1
                 op_count_incremented = True
-                # Emission is deferred to the outer `except` below (which
-                # runs for any exception raised inside this `try`, unlike
-                # the pre-refactor code where this check lived outside the
-                # `try`); emitting here too would double-emit the event.
+                # The outer `except` below emits for any exception raised in
+                # this `try`, so emitting here too would double-emit.
                 self._raise_if_not_ready(checkout_started_time, emit_event=False)
                 if self.requests < self.max_pool_size:
                     # Fast path: a slot is immediately available, so do all
-                    # of the counter bookkeeping in this single critical
-                    # section instead of taking the lock multiple times.
+                    # of the counter bookkeeping in this one critical section
+                    # and keep the checkout to a single lock acquisition.
                     self.requests += 1
                     requests_incremented = True
                     self.active_sockets += 1
                     active_sockets_incremented = True
 
             if not requests_incremented:
-                # Slow path: no slot was free. Fall back to waiting on the
-                # requests semaphore, exactly as before.
+                # Slow path: no slot was free, so wait on the requests
+                # semaphore for one to be released.
                 with self.size_cond:
                     self._raise_if_not_ready(checkout_started_time, emit_event=False)
                     while not (self.requests < self.max_pool_size):

--- a/pymongo/topology_description.py
+++ b/pymongo/topology_description.py
@@ -290,9 +290,14 @@ class TopologyDescription:
         If every known server is deprioritized, all known servers are returned
         so that selection can still make progress.
 
-        This method must not mutate ``self``: server selection runs it while
-        holding only a shared read lock, so concurrent callers with different
-        ``deprioritized_servers`` would otherwise clobber each other's results.
+        This method must not mutate ``self``: TopologyDescription is a shared,
+        publicly-exposed immutable snapshot, and deprioritization is specific
+        to a single selection call. Caching the filtered list on ``self``
+        would leave the public :attr:`candidate_servers` property stale after
+        any selection that deprioritized servers, which is what used to make
+        :meth:`~pymongo.synchronous.topology.Topology.get_primary` (and
+        ``client.primary``) raise ``IndexError`` after a retryable operation
+        deprioritized the primary.
 
         :param deprioritized_servers: servers to exclude, or None.
         """

--- a/pymongo/topology_description.py
+++ b/pymongo/topology_description.py
@@ -371,7 +371,9 @@ class TopologyDescription:
             selection = selector(selection)
             # No suitable servers found, apply preference again but include deprioritized servers.
             if not selection and deprioritized_servers:
-                selection = Selection.from_topology_description(self, self._filter_servers(None))
+                # No candidate filtering: from_topology_description() defaults
+                # to all known servers.
+                selection = Selection.from_topology_description(self)
                 selection = selector(selection)
 
         # Apply custom selector followed by localThresholdMS.

--- a/pymongo/topology_description.py
+++ b/pymongo/topology_description.py
@@ -84,7 +84,6 @@ class TopologyDescription:
         self._server_descriptions = server_descriptions
         self._max_set_version = max_set_version
         self._max_election_id = max_election_id
-        self._candidate_servers = list(self._server_descriptions.values())
 
         # The heartbeat_frequency is used in staleness estimates.
         self._topology_settings = topology_settings
@@ -240,8 +239,13 @@ class TopologyDescription:
 
     @property
     def candidate_servers(self) -> list[ServerDescription]:
-        """List of Servers excluding deprioritized servers."""
-        return self._candidate_servers
+        """List of Servers eligible for selection when nothing is deprioritized.
+
+        Deprioritization is per server-selection call, so it is applied by
+        :meth:`apply_selector` (via :meth:`_filter_servers`) and deliberately
+        not cached on the (immutable) TopologyDescription.
+        """
+        return self.known_servers
 
     @property
     def common_wire_version(self) -> Optional[int]:
@@ -280,18 +284,27 @@ class TopologyDescription:
 
     def _filter_servers(
         self, deprioritized_servers: Optional[list[ServerDescription]] = None
-    ) -> None:
-        """Filter out deprioritized servers from a list of server candidates."""
+    ) -> list[ServerDescription]:
+        """Return the known servers with any deprioritized servers filtered out.
+
+        If every known server is deprioritized, all known servers are returned
+        so that selection can still make progress.
+
+        This method must not mutate ``self``: server selection runs it while
+        holding only a shared read lock, so concurrent callers with different
+        ``deprioritized_servers`` would otherwise clobber each other's results.
+
+        :param deprioritized_servers: servers to exclude, or None.
+        """
+        known_servers = self.known_servers
         if not deprioritized_servers:
-            self._candidate_servers = self.known_servers
-        else:
-            deprioritized_addresses = {sd.address for sd in deprioritized_servers}
-            filtered = [
-                server
-                for server in self.known_servers
-                if server.address not in deprioritized_addresses
-            ]
-            self._candidate_servers = filtered or self.known_servers
+            return known_servers
+
+        deprioritized_addresses = {sd.address for sd in deprioritized_servers}
+        filtered = [
+            server for server in known_servers if server.address not in deprioritized_addresses
+        ]
+        return filtered or known_servers
 
     def apply_selector(
         self,
@@ -335,10 +348,10 @@ class TopologyDescription:
             description = self.server_descriptions().get(address)
             return [description] if description and description.is_server_type_known else []
 
-        self._filter_servers(deprioritized_servers)
+        candidate_servers = self._filter_servers(deprioritized_servers)
         # Primary selection fast path.
         if self.topology_type == TOPOLOGY_TYPE.ReplicaSetWithPrimary and type(selector) is Primary:
-            for sd in self._candidate_servers:
+            for sd in candidate_servers:
                 if sd.server_type == SERVER_TYPE.RSPrimary:
                     sds = [sd]
                     if custom_selector:
@@ -355,14 +368,13 @@ class TopologyDescription:
             # No primary found, return an empty list.
             return []
 
-        selection = Selection.from_topology_description(self)
+        selection = Selection.from_topology_description(self, candidate_servers)
         # Ignore read preference for sharded clusters.
         if self.topology_type != TOPOLOGY_TYPE.Sharded:
             selection = selector(selection)
             # No suitable servers found, apply preference again but include deprioritized servers.
             if not selection and deprioritized_servers:
-                self._filter_servers(None)
-                selection = Selection.from_topology_description(self)
+                selection = Selection.from_topology_description(self, self._filter_servers(None))
                 selection = selector(selection)
 
         # Apply custom selector followed by localThresholdMS.

--- a/pymongo/topology_description.py
+++ b/pymongo/topology_description.py
@@ -280,11 +280,11 @@ class TopologyDescription:
         If every known server is deprioritized, all known servers are returned
         so that selection can still make progress.
 
-        This method must not mutate ``self``: TopologyDescription is a shared,
-        publicly-exposed immutable snapshot, and deprioritization is specific
-        to a single selection call. Caching the filtered list on ``self``
-        would leave the public :attr:`candidate_servers` property stale after
-        any selection that deprioritized servers, which is what used to make
+        This method must not mutate ``self``: a TopologyDescription is shared
+        by every concurrent selection call and is replaced, not edited, when
+        the topology changes. Deprioritization is specific to a single call,
+        so caching the filtered list on ``self`` outlived the call that
+        produced it, which is what used to make
         :meth:`~pymongo.synchronous.topology.Topology.get_primary` (and
         ``client.primary``) raise ``IndexError`` after a retryable operation
         deprioritized the primary.

--- a/pymongo/topology_description.py
+++ b/pymongo/topology_description.py
@@ -280,14 +280,13 @@ class TopologyDescription:
         If every known server is deprioritized, all known servers are returned
         so that selection can still make progress.
 
-        This method must not mutate ``self``: a TopologyDescription is shared
+        This method must not mutate ``self``. A TopologyDescription is shared
         by every concurrent selection call and is replaced, not edited, when
-        the topology changes. Deprioritization is specific to a single call,
-        so caching the filtered list on ``self`` outlived the call that
-        produced it, which is what used to make
-        :meth:`~pymongo.synchronous.topology.Topology.get_primary` (and
-        ``client.primary``) raise ``IndexError`` after a retryable operation
-        deprioritized the primary.
+        the topology changes, while deprioritization is specific to a single
+        call. Callers such as
+        :meth:`~pymongo.synchronous.topology.Topology.get_primary` build their
+        selection straight from the description, so any filtering left on it
+        would be applied to selections that never asked for it.
 
         :param deprioritized_servers: servers to exclude, or None.
         """

--- a/pymongo/topology_description.py
+++ b/pymongo/topology_description.py
@@ -238,16 +238,6 @@ class TopologyDescription:
         return [s for s in self._server_descriptions.values() if s.is_readable]
 
     @property
-    def candidate_servers(self) -> list[ServerDescription]:
-        """List of Servers eligible for selection when nothing is deprioritized.
-
-        Deprioritization is per server-selection call, so it is applied by
-        :meth:`apply_selector` (via :meth:`_filter_servers`) and deliberately
-        not cached on the (immutable) TopologyDescription.
-        """
-        return self.known_servers
-
-    @property
     def common_wire_version(self) -> Optional[int]:
         """Minimum of all servers' max wire versions, or None."""
         servers = self.known_servers

--- a/pymongo/topology_description.py
+++ b/pymongo/topology_description.py
@@ -280,13 +280,16 @@ class TopologyDescription:
         If every known server is deprioritized, all known servers are returned
         so that selection can still make progress.
 
-        This method must not mutate ``self``. A TopologyDescription is shared
-        by every concurrent selection call and is replaced, not edited, when
-        the topology changes, while deprioritization is specific to a single
-        call. Callers such as
+        This method must not mutate ``self``. Deprioritization is specific to
+        a single call, but a TopologyDescription outlives it and is replaced,
+        not edited, when the topology changes. Filtering left behind on the
+        description would therefore leak into later readers: callers such as
         :meth:`~pymongo.synchronous.topology.Topology.get_primary` build their
-        selection straight from the description, so any filtering left on it
-        would be applied to selections that never asked for it.
+        selection straight from the description and would see a view narrowed
+        by a selection they never asked for. The same object is also handed to
+        code running on other threads -- topology event listeners and anything
+        holding :attr:`~pymongo.mongo_client.MongoClient.topology_description`
+        -- which may read it concurrently with a selection in progress.
 
         :param deprioritized_servers: servers to exclude, or None.
         """

--- a/test/asynchronous/test_pooling.py
+++ b/test/asynchronous/test_pooling.py
@@ -32,16 +32,18 @@ from bson.son import SON
 from pymongo import AsyncMongoClient, message, timeout
 from pymongo.errors import AutoReconnect, ConnectionFailure, DuplicateKeyError
 from pymongo.hello import HelloCompat
-from pymongo.lock import _async_create_lock
+from pymongo.lock import _async_cond_wait, _async_create_lock
 from pymongo.monitoring import (
     ConnectionCheckOutFailedEvent,
     ConnectionCheckOutFailedReason,
+    PoolClearedEvent,
     _EventListeners,
 )
 from test.asynchronous.utils import async_get_pool, async_joinall, flaky
 
 sys.path[0:0] = [""]
 
+from pymongo.asynchronous import pool as pool_module
 from pymongo.asynchronous.pool import Pool, PoolOptions
 from pymongo.socket_checker import SocketChecker
 from test.asynchronous import AsyncIntegrationTest, async_client_context, unittest
@@ -280,6 +282,7 @@ class TestPooling(_TestPoolingBase):
         # Bookkeeping must be rolled back, not left half-updated.
         self.assertEqual(0, cx_pool.active_sockets)
         self.assertEqual(0, cx_pool.requests)
+        self.assertEqual(0, cx_pool.operation_count)
 
     async def test_pool_removes_closed_socket(self):
         # Test that Pool removes explicitly closed socket.
@@ -493,6 +496,88 @@ class TestPooling(_TestPoolingBase):
             [True],
             locked_while_emitting,
             "ConnectionCheckOutFailedEvent must be published while the pool mutex is held",
+        )
+
+    async def test_checkout_failed_event_is_emitted_under_the_pool_lock_slow_path(self):
+        # Same guarantee as the test above, but for the readiness checks on
+        # the slow path. That test pauses an idle pool, so a slot is free and
+        # only the fast path runs; moving emission out from under the mutex in
+        # the slow path alone would not fail it. Here the pool's only slot is
+        # already taken, so the checkout blocks on size_cond, and reset()
+        # wakes it. This is exactly the PYTHON-3519 scenario: _reset()
+        # publishes PoolClearedEvent and calls notify_all() while holding the
+        # mutex, so the woken checkout can only publish its
+        # ConnectionCheckOutFailedEvent afterwards -- but only if it, too,
+        # publishes while still holding the mutex.
+        locked_while_emitting = []
+        pool_ref: list = []
+
+        class LockObservingListener(CMAPListener):
+            def connection_check_out_failed(self, event):
+                locked_while_emitting.append(pool_ref[0].lock.locked())
+                super().connection_check_out_failed(event)
+
+        listener = LockObservingListener()
+        pool = await self.create_pool(max_pool_size=1, event_listeners=_EventListeners([listener]))
+        self.addAsyncCleanup(pool.close)
+        pool_ref.append(pool)
+
+        errors: list = []
+
+        async def blocked_checkout():
+            try:
+                async with pool.checkout():
+                    pass
+            except BaseException as exc:
+                errors.append(exc)
+
+        # The checkout must be parked on size_cond before the pool is reset,
+        # otherwise it could still fail on the fast path and this test would
+        # silently duplicate the one above. Flag it from inside the condition
+        # wait itself: the flag is set while size_cond is still held, so
+        # reset() cannot acquire the mutex until the checkout has released it
+        # by blocking.
+        parked: list = []
+        real_cond_wait = _async_cond_wait
+
+        async def flagging_cond_wait(condition, timeout):
+            if condition is pool.size_cond:
+                parked.append(True)
+            return await real_cond_wait(condition, timeout)
+
+        with patch.object(pool_module, "_async_cond_wait", flagging_cond_wait):
+            async with pool.checkout():
+                listener.reset()
+                task = ConcurrentRunner(target=blocked_checkout, name="blocked_checkout")
+                await task.start()
+
+                start = time.monotonic()
+                while not parked:  # noqa: ASYNC110, RUF100
+                    self.assertLess(
+                        time.monotonic() - start, 30, "checkout never blocked on size_cond"
+                    )
+                    await asyncio.sleep(0.01)
+
+                await pool.reset()  # Pause the pool and wake the blocked checkout.
+                await task.join(30)
+                self.assertFalse(task.is_alive(), "blocked checkout never finished")
+
+        self.assertEqual(1, len(errors), f"expected exactly one failed checkout, got {errors}")
+        self.assertIsInstance(errors[0], AutoReconnect)
+        self.assertEqual(
+            [True],
+            locked_while_emitting,
+            "ConnectionCheckOutFailedEvent must be published while the pool mutex is held",
+        )
+        # PYTHON-3519: the clear that caused the failure must be recorded first.
+        self.assertEqual(
+            [PoolClearedEvent, ConnectionCheckOutFailedEvent],
+            [
+                type(event)
+                for event in listener.events_by_type(
+                    (PoolClearedEvent, ConnectionCheckOutFailedEvent)
+                )
+            ],
         )
 
     async def test_no_wait_queue_timeout(self):

--- a/test/asynchronous/test_pooling.py
+++ b/test/asynchronous/test_pooling.py
@@ -630,6 +630,64 @@ class TestPooling(_TestPoolingBase):
             f"{checkout_acquires}",
         )
 
+    async def test_contended_checkout_pool_lock_acquisitions(self):
+        # The same guarantee as the test above, for a checkout that has to
+        # wait for a slot: its requests and active_sockets bookkeeping belongs
+        # in the one size_cond critical section, not in a further acquisition
+        # afterwards.
+        #
+        # Driven from a single task so the count is not polluted by the
+        # releasing side -- checkin() acquires the pool lock twice itself. The
+        # slot is freed from inside the condition wait, which is where a real
+        # waiter would be woken.
+        pool = await self.create_pool(max_pool_size=1)
+        self.addAsyncCleanup(pool.close)
+
+        async with pool.checkout():
+            pass
+
+        # Make the fast path's slot check fail so the slow path runs.
+        pool.requests = pool.max_pool_size
+
+        real_cond_wait = _async_cond_wait
+
+        async def releasing_cond_wait(condition, timeout):
+            if condition is pool.size_cond:
+                pool.requests = 0
+                return True
+            return await real_cond_wait(condition, timeout)
+
+        acquires = 0
+        real_lock = pool.lock
+
+        class CountingLock:
+            async def __aenter__(self):
+                nonlocal acquires
+                acquires += 1
+                return await real_lock.__aenter__()
+
+            async def __aexit__(self, *args):
+                return await real_lock.__aexit__(*args)
+
+            def __getattr__(self, name):
+                return getattr(real_lock, name)
+
+        pool.lock = CountingLock()  # type: ignore[assignment]
+        try:
+            with patch.object(pool_module, "_async_cond_wait", releasing_cond_wait):
+                async with pool.checkout():
+                    checkout_acquires = acquires
+        finally:
+            pool.lock = real_lock
+
+        self.assertEqual(
+            2,
+            checkout_acquires,
+            f"a checkout that waited for a slot should acquire the pool lock twice -- "
+            f"once for counter bookkeeping and once to register the cancel context -- "
+            f"got {checkout_acquires}",
+        )
+
     async def test_no_wait_queue_timeout(self):
         # Verify get_socket() with no wait_queue_timeout blocks forever.
         pool = await self.create_pool(max_pool_size=1)

--- a/test/asynchronous/test_pooling.py
+++ b/test/asynchronous/test_pooling.py
@@ -399,6 +399,24 @@ class TestPooling(_TestPoolingBase):
             f"Waited {duration:.2f} seconds for a socket, expected {wait_queue_timeout:f}",
         )
 
+    async def test_wait_queue_timeout_does_not_leak_operation_count(self):
+        # Regression test: a checkout that fails while waiting for a pool
+        # slot must not leave operation_count permanently incremented.
+        wait_queue_timeout = 1  # Seconds
+        pool = await self.create_pool(max_pool_size=1, wait_queue_timeout=wait_queue_timeout)
+        self.addAsyncCleanup(pool.close)
+
+        async with pool.checkout():
+            self.assertEqual(pool.operation_count, 1)
+            with self.assertRaises(ConnectionFailure):
+                async with pool.checkout():
+                    pass
+            # The failed second checkout must not have left operation_count
+            # incremented for its own (failed) attempt.
+            self.assertEqual(pool.operation_count, 1)
+
+        self.assertEqual(pool.operation_count, 0)
+
     async def test_no_wait_queue_timeout(self):
         # Verify get_socket() with no wait_queue_timeout blocks forever.
         pool = await self.create_pool(max_pool_size=1)

--- a/test/asynchronous/test_pooling.py
+++ b/test/asynchronous/test_pooling.py
@@ -580,6 +580,56 @@ class TestPooling(_TestPoolingBase):
             ],
         )
 
+    async def test_uncontended_checkout_pool_lock_acquisitions(self):
+        # An uncontended checkout must do all of its operation_count,
+        # requests and active_sockets bookkeeping in a single critical
+        # section. Pinning the acquisition count keeps that from silently
+        # regressing: splitting the bookkeeping back apart would still pass
+        # every other test in this file.
+        #
+        # Two acquisitions are expected for a warm checkout that reuses an
+        # idle connection: one for the merged bookkeeping, and one to
+        # register the connection's cancel context. size_cond and
+        # _max_connecting_cond are distinct objects wrapping the same mutex,
+        # so their blocks are not counted here.
+        pool = await self.create_pool(max_pool_size=1)
+        self.addAsyncCleanup(pool.close)
+
+        # Check a connection out and back in first, so this measurement
+        # covers a warm pool and does not include connection establishment.
+        async with pool.checkout():
+            pass
+
+        acquires = 0
+        real_lock = pool.lock
+
+        class CountingLock:
+            async def __aenter__(self):
+                nonlocal acquires
+                acquires += 1
+                return await real_lock.__aenter__()
+
+            async def __aexit__(self, *args):
+                return await real_lock.__aexit__(*args)
+
+            def __getattr__(self, name):
+                return getattr(real_lock, name)
+
+        pool.lock = CountingLock()  # type: ignore[assignment]
+        try:
+            async with pool.checkout():
+                checkout_acquires = acquires
+        finally:
+            pool.lock = real_lock
+
+        self.assertEqual(
+            2,
+            checkout_acquires,
+            f"an uncontended checkout should acquire the pool lock twice -- once for "
+            f"counter bookkeeping and once to register the cancel context -- got "
+            f"{checkout_acquires}",
+        )
+
     async def test_no_wait_queue_timeout(self):
         # Verify get_socket() with no wait_queue_timeout blocks forever.
         pool = await self.create_pool(max_pool_size=1)

--- a/test/asynchronous/test_pooling.py
+++ b/test/asynchronous/test_pooling.py
@@ -462,6 +462,39 @@ class TestPooling(_TestPoolingBase):
         self.assertEqual(len(failed_events), 1, [e.reason for e in failed_events])
         self.assertEqual(failed_events[0].reason, ConnectionCheckOutFailedReason.CONN_ERROR)
 
+    async def test_checkout_failed_event_is_emitted_under_the_pool_lock(self):
+        # A readiness check that fails must publish its
+        # ConnectionCheckOutFailedEvent while still holding the pool mutex.
+        # _reset() publishes PoolClearedEvent under that same mutex precisely
+        # so that it is always recorded first; deferring the checkout failure
+        # to after the mutex is released loses that ordering (PYTHON-3519).
+        # Listeners are invoked synchronously inside the publish call, so this
+        # one observes directly whether the emitting code holds the mutex.
+        locked_while_emitting = []
+        pool_ref: list = []
+
+        class LockObservingListener(CMAPListener):
+            def connection_check_out_failed(self, event):
+                locked_while_emitting.append(pool_ref[0].lock.locked())
+                super().connection_check_out_failed(event)
+
+        listener = LockObservingListener()
+        pool = await self.create_pool(max_pool_size=1, event_listeners=_EventListeners([listener]))
+        self.addAsyncCleanup(pool.close)
+        pool_ref.append(pool)
+
+        await pool.reset()  # Pause the pool.
+        listener.reset()
+        with self.assertRaises(AutoReconnect):
+            async with pool.checkout():
+                pass
+
+        self.assertEqual(
+            [True],
+            locked_while_emitting,
+            "ConnectionCheckOutFailedEvent must be published while the pool mutex is held",
+        )
+
     async def test_no_wait_queue_timeout(self):
         # Verify get_socket() with no wait_queue_timeout blocks forever.
         pool = await self.create_pool(max_pool_size=1)

--- a/test/asynchronous/test_pooling.py
+++ b/test/asynchronous/test_pooling.py
@@ -33,7 +33,11 @@ from pymongo import AsyncMongoClient, message, timeout
 from pymongo.errors import AutoReconnect, ConnectionFailure, DuplicateKeyError
 from pymongo.hello import HelloCompat
 from pymongo.lock import _async_create_lock
-from pymongo.monitoring import _EventListeners
+from pymongo.monitoring import (
+    ConnectionCheckOutFailedEvent,
+    ConnectionCheckOutFailedReason,
+    _EventListeners,
+)
 from test.asynchronous.utils import async_get_pool, async_joinall, flaky
 
 sys.path[0:0] = [""]
@@ -401,21 +405,66 @@ class TestPooling(_TestPoolingBase):
 
     async def test_wait_queue_timeout_does_not_leak_operation_count(self):
         # Regression test: a checkout that fails while waiting for a pool
-        # slot must not leave operation_count permanently incremented.
+        # slot must not leave operation_count, requests, or active_sockets
+        # permanently incremented, and must emit exactly one
+        # ConnectionCheckOutFailedEvent with reason TIMEOUT (not a second,
+        # bogus CONN_ERROR event from the outer except block).
         wait_queue_timeout = 1  # Seconds
-        pool = await self.create_pool(max_pool_size=1, wait_queue_timeout=wait_queue_timeout)
+        listener = CMAPListener()
+        pool = await self.create_pool(
+            max_pool_size=1,
+            wait_queue_timeout=wait_queue_timeout,
+            event_listeners=_EventListeners([listener]),
+        )
         self.addAsyncCleanup(pool.close)
 
         async with pool.checkout():
             self.assertEqual(pool.operation_count, 1)
+            self.assertEqual(pool.requests, 1)
+            self.assertEqual(pool.active_sockets, 1)
+            listener.reset()
             with self.assertRaises(ConnectionFailure):
                 async with pool.checkout():
                     pass
-            # The failed second checkout must not have left operation_count
+            # The failed second checkout must not have left any counter
             # incremented for its own (failed) attempt.
             self.assertEqual(pool.operation_count, 1)
+            self.assertEqual(pool.requests, 1)
+            self.assertEqual(pool.active_sockets, 1)
+
+            failed_events = listener.events_by_type(ConnectionCheckOutFailedEvent)
+            self.assertEqual(len(failed_events), 1, [e.reason for e in failed_events])
+            self.assertEqual(failed_events[0].reason, ConnectionCheckOutFailedReason.TIMEOUT)
 
         self.assertEqual(pool.operation_count, 0)
+        self.assertEqual(pool.requests, 0)
+        self.assertEqual(pool.active_sockets, 0)
+
+    async def test_paused_pool_checkout_failure_does_not_leak_or_double_emit(self):
+        # Regression test: a checkout that fails because the pool is paused
+        # (not ready) must not leave operation_count, requests, or
+        # active_sockets permanently incremented, and must emit exactly one
+        # ConnectionCheckOutFailedEvent (not a second, bogus one from the
+        # outer except block). With no outstanding checkouts, a slot is
+        # immediately available, so this exercises the fast path's
+        # _raise_if_not_ready check.
+        listener = CMAPListener()
+        pool = await self.create_pool(max_pool_size=1, event_listeners=_EventListeners([listener]))
+        self.addAsyncCleanup(pool.close)
+
+        await pool.reset()  # Pause the pool.
+        listener.reset()
+        with self.assertRaises(AutoReconnect):
+            async with pool.checkout():
+                pass
+
+        self.assertEqual(pool.operation_count, 0)
+        self.assertEqual(pool.requests, 0)
+        self.assertEqual(pool.active_sockets, 0)
+
+        failed_events = listener.events_by_type(ConnectionCheckOutFailedEvent)
+        self.assertEqual(len(failed_events), 1, [e.reason for e in failed_events])
+        self.assertEqual(failed_events[0].reason, ConnectionCheckOutFailedReason.CONN_ERROR)
 
     async def test_no_wait_queue_timeout(self):
         # Verify get_socket() with no wait_queue_timeout blocks forever.

--- a/test/asynchronous/test_pooling.py
+++ b/test/asynchronous/test_pooling.py
@@ -404,11 +404,9 @@ class TestPooling(_TestPoolingBase):
         )
 
     async def test_wait_queue_timeout_does_not_leak_operation_count(self):
-        # Regression test: a checkout that fails while waiting for a pool
-        # slot must not leave operation_count, requests, or active_sockets
-        # permanently incremented, and must emit exactly one
-        # ConnectionCheckOutFailedEvent with reason TIMEOUT (not a second,
-        # bogus CONN_ERROR event from the outer except block).
+        # A checkout that fails while waiting for a pool slot must not leave
+        # operation_count, requests, or active_sockets incremented, and must
+        # emit exactly one ConnectionCheckOutFailedEvent, with reason TIMEOUT.
         wait_queue_timeout = 1  # Seconds
         listener = CMAPListener()
         pool = await self.create_pool(
@@ -441,13 +439,11 @@ class TestPooling(_TestPoolingBase):
         self.assertEqual(pool.active_sockets, 0)
 
     async def test_paused_pool_checkout_failure_does_not_leak_or_double_emit(self):
-        # Regression test: a checkout that fails because the pool is paused
-        # (not ready) must not leave operation_count, requests, or
-        # active_sockets permanently incremented, and must emit exactly one
-        # ConnectionCheckOutFailedEvent (not a second, bogus one from the
-        # outer except block). With no outstanding checkouts, a slot is
-        # immediately available, so this exercises the fast path's
-        # _raise_if_not_ready check.
+        # A checkout that fails because the pool is paused must not leave
+        # operation_count, requests, or active_sockets incremented, and must
+        # emit exactly one ConnectionCheckOutFailedEvent. With no outstanding
+        # checkouts a slot is immediately available, so this exercises the
+        # fast path's readiness check.
         listener = CMAPListener()
         pool = await self.create_pool(max_pool_size=1, event_listeners=_EventListeners([listener]))
         self.addAsyncCleanup(pool.close)

--- a/test/test_pooling.py
+++ b/test/test_pooling.py
@@ -630,6 +630,64 @@ class TestPooling(_TestPoolingBase):
             f"{checkout_acquires}",
         )
 
+    def test_contended_checkout_pool_lock_acquisitions(self):
+        # The same guarantee as the test above, for a checkout that has to
+        # wait for a slot: its requests and active_sockets bookkeeping belongs
+        # in the one size_cond critical section, not in a further acquisition
+        # afterwards.
+        #
+        # Driven from a single task so the count is not polluted by the
+        # releasing side -- checkin() acquires the pool lock twice itself. The
+        # slot is freed from inside the condition wait, which is where a real
+        # witer would be woken.
+        pool = self.create_pool(max_pool_size=1)
+        self.addCleanup(pool.close)
+
+        with pool.checkout():
+            pass
+
+        # Make the fast path's slot check fail so the slow path runs.
+        pool.requests = pool.max_pool_size
+
+        real_cond_wait = _cond_wait
+
+        def releasing_cond_wait(condition, timeout):
+            if condition is pool.size_cond:
+                pool.requests = 0
+                return True
+            return real_cond_wait(condition, timeout)
+
+        acquires = 0
+        real_lock = pool.lock
+
+        class CountingLock:
+            def __enter__(self):
+                nonlocal acquires
+                acquires += 1
+                return real_lock.__enter__()
+
+            def __exit__(self, *args):
+                return real_lock.__exit__(*args)
+
+            def __getattr__(self, name):
+                return getattr(real_lock, name)
+
+        pool.lock = CountingLock()  # type: ignore[assignment]
+        try:
+            with patch.object(pool_module, "_cond_wait", releasing_cond_wait):
+                with pool.checkout():
+                    checkout_acquires = acquires
+        finally:
+            pool.lock = real_lock
+
+        self.assertEqual(
+            2,
+            checkout_acquires,
+            f"a checkout that waited for a slot should acquire the pool lock twice -- "
+            f"once for counter bookkeeping and once to register the cancel context -- "
+            f"got {checkout_acquires}",
+        )
+
     def test_no_wait_queue_timeout(self):
         # Verify get_socket() with no wait_queue_timeout blocks forever.
         pool = self.create_pool(max_pool_size=1)

--- a/test/test_pooling.py
+++ b/test/test_pooling.py
@@ -33,7 +33,11 @@ from pymongo import MongoClient, message, timeout
 from pymongo.errors import AutoReconnect, ConnectionFailure, DuplicateKeyError
 from pymongo.hello import HelloCompat
 from pymongo.lock import _create_lock
-from pymongo.monitoring import _EventListeners
+from pymongo.monitoring import (
+    ConnectionCheckOutFailedEvent,
+    ConnectionCheckOutFailedReason,
+    _EventListeners,
+)
 from test.utils import flaky, get_pool, joinall
 
 sys.path[0:0] = [""]
@@ -401,21 +405,66 @@ class TestPooling(_TestPoolingBase):
 
     def test_wait_queue_timeout_does_not_leak_operation_count(self):
         # Regression test: a checkout that fails while waiting for a pool
-        # slot must not leave operation_count permanently incremented.
+        # slot must not leave operation_count, requests, or active_sockets
+        # permanently incremented, and must emit exactly one
+        # ConnectionCheckOutFailedEvent with reason TIMEOUT (not a second,
+        # bogus CONN_ERROR event from the outer except block).
         wait_queue_timeout = 1  # Seconds
-        pool = self.create_pool(max_pool_size=1, wait_queue_timeout=wait_queue_timeout)
+        listener = CMAPListener()
+        pool = self.create_pool(
+            max_pool_size=1,
+            wait_queue_timeout=wait_queue_timeout,
+            event_listeners=_EventListeners([listener]),
+        )
         self.addCleanup(pool.close)
 
         with pool.checkout():
             self.assertEqual(pool.operation_count, 1)
+            self.assertEqual(pool.requests, 1)
+            self.assertEqual(pool.active_sockets, 1)
+            listener.reset()
             with self.assertRaises(ConnectionFailure):
                 with pool.checkout():
                     pass
-            # The failed second checkout must not have left operation_count
+            # The failed second checkout must not have left any counter
             # incremented for its own (failed) attempt.
             self.assertEqual(pool.operation_count, 1)
+            self.assertEqual(pool.requests, 1)
+            self.assertEqual(pool.active_sockets, 1)
+
+            failed_events = listener.events_by_type(ConnectionCheckOutFailedEvent)
+            self.assertEqual(len(failed_events), 1, [e.reason for e in failed_events])
+            self.assertEqual(failed_events[0].reason, ConnectionCheckOutFailedReason.TIMEOUT)
 
         self.assertEqual(pool.operation_count, 0)
+        self.assertEqual(pool.requests, 0)
+        self.assertEqual(pool.active_sockets, 0)
+
+    def test_paused_pool_checkout_failure_does_not_leak_or_double_emit(self):
+        # Regression test: a checkout that fails because the pool is paused
+        # (not ready) must not leave operation_count, requests, or
+        # active_sockets permanently incremented, and must emit exactly one
+        # ConnectionCheckOutFailedEvent (not a second, bogus one from the
+        # outer except block). With no outstanding checkouts, a slot is
+        # immediately available, so this exercises the fast path's
+        # _raise_if_not_ready check.
+        listener = CMAPListener()
+        pool = self.create_pool(max_pool_size=1, event_listeners=_EventListeners([listener]))
+        self.addCleanup(pool.close)
+
+        pool.reset()  # Pause the pool.
+        listener.reset()
+        with self.assertRaises(AutoReconnect):
+            with pool.checkout():
+                pass
+
+        self.assertEqual(pool.operation_count, 0)
+        self.assertEqual(pool.requests, 0)
+        self.assertEqual(pool.active_sockets, 0)
+
+        failed_events = listener.events_by_type(ConnectionCheckOutFailedEvent)
+        self.assertEqual(len(failed_events), 1, [e.reason for e in failed_events])
+        self.assertEqual(failed_events[0].reason, ConnectionCheckOutFailedReason.CONN_ERROR)
 
     def test_no_wait_queue_timeout(self):
         # Verify get_socket() with no wait_queue_timeout blocks forever.

--- a/test/test_pooling.py
+++ b/test/test_pooling.py
@@ -580,6 +580,56 @@ class TestPooling(_TestPoolingBase):
             ],
         )
 
+    def test_uncontended_checkout_pool_lock_acquisitions(self):
+        # An uncontended checkout must do all of its operation_count,
+        # requests and active_sockets bookkeeping in a single critical
+        # section. Pinning the acquisition count keeps that from silently
+        # regressing: splitting the bookkeeping back apart would still pass
+        # every other test in this file.
+        #
+        # Two acquisitions are expected for a warm checkout that reuses an
+        # idle connection: one for the merged bookkeeping, and one to
+        # register the connection's cancel context. size_cond and
+        # _max_connecting_cond are distinct objects wrapping the same mutex,
+        # so their blocks are not counted here.
+        pool = self.create_pool(max_pool_size=1)
+        self.addCleanup(pool.close)
+
+        # Check a connection out and back in first, so this measurement
+        # covers a warm pool and does not include connection establishment.
+        with pool.checkout():
+            pass
+
+        acquires = 0
+        real_lock = pool.lock
+
+        class CountingLock:
+            def __enter__(self):
+                nonlocal acquires
+                acquires += 1
+                return real_lock.__enter__()
+
+            def __exit__(self, *args):
+                return real_lock.__exit__(*args)
+
+            def __getattr__(self, name):
+                return getattr(real_lock, name)
+
+        pool.lock = CountingLock()  # type: ignore[assignment]
+        try:
+            with pool.checkout():
+                checkout_acquires = acquires
+        finally:
+            pool.lock = real_lock
+
+        self.assertEqual(
+            2,
+            checkout_acquires,
+            f"an uncontended checkout should acquire the pool lock twice -- once for "
+            f"counter bookkeeping and once to register the cancel context -- got "
+            f"{checkout_acquires}",
+        )
+
     def test_no_wait_queue_timeout(self):
         # Verify get_socket() with no wait_queue_timeout blocks forever.
         pool = self.create_pool(max_pool_size=1)

--- a/test/test_pooling.py
+++ b/test/test_pooling.py
@@ -404,11 +404,9 @@ class TestPooling(_TestPoolingBase):
         )
 
     def test_wait_queue_timeout_does_not_leak_operation_count(self):
-        # Regression test: a checkout that fails while waiting for a pool
-        # slot must not leave operation_count, requests, or active_sockets
-        # permanently incremented, and must emit exactly one
-        # ConnectionCheckOutFailedEvent with reason TIMEOUT (not a second,
-        # bogus CONN_ERROR event from the outer except block).
+        # A checkout that fails while waiting for a pool slot must not leave
+        # operation_count, requests, or active_sockets incremented, and must
+        # emit exactly one ConnectionCheckOutFailedEvent, with reason TIMEOUT.
         wait_queue_timeout = 1  # Seconds
         listener = CMAPListener()
         pool = self.create_pool(
@@ -441,13 +439,11 @@ class TestPooling(_TestPoolingBase):
         self.assertEqual(pool.active_sockets, 0)
 
     def test_paused_pool_checkout_failure_does_not_leak_or_double_emit(self):
-        # Regression test: a checkout that fails because the pool is paused
-        # (not ready) must not leave operation_count, requests, or
-        # active_sockets permanently incremented, and must emit exactly one
-        # ConnectionCheckOutFailedEvent (not a second, bogus one from the
-        # outer except block). With no outstanding checkouts, a slot is
-        # immediately available, so this exercises the fast path's
-        # _raise_if_not_ready check.
+        # A checkout that fails because the pool is paused must not leave
+        # operation_count, requests, or active_sockets incremented, and must
+        # emit exactly one ConnectionCheckOutFailedEvent. With no outstanding
+        # checkouts a slot is immediately available, so this exercises the
+        # fast path's readiness check.
         listener = CMAPListener()
         pool = self.create_pool(max_pool_size=1, event_listeners=_EventListeners([listener]))
         self.addCleanup(pool.close)

--- a/test/test_pooling.py
+++ b/test/test_pooling.py
@@ -462,6 +462,39 @@ class TestPooling(_TestPoolingBase):
         self.assertEqual(len(failed_events), 1, [e.reason for e in failed_events])
         self.assertEqual(failed_events[0].reason, ConnectionCheckOutFailedReason.CONN_ERROR)
 
+    def test_checkout_failed_event_is_emitted_under_the_pool_lock(self):
+        # A readiness check that fails must publish its
+        # ConnectionCheckOutFailedEvent while still holding the pool mutex.
+        # _reset() publishes PoolClearedEvent under that same mutex precisely
+        # so that it is always recorded first; deferring the checkout failure
+        # to after the mutex is released loses that ordering (PYTHON-3519).
+        # Listeners are invoked synchronously inside the publish call, so this
+        # one observes directly whether the emitting code holds the mutex.
+        locked_while_emitting = []
+        pool_ref: list = []
+
+        class LockObservingListener(CMAPListener):
+            def connection_check_out_failed(self, event):
+                locked_while_emitting.append(pool_ref[0].lock.locked())
+                super().connection_check_out_failed(event)
+
+        listener = LockObservingListener()
+        pool = self.create_pool(max_pool_size=1, event_listeners=_EventListeners([listener]))
+        self.addCleanup(pool.close)
+        pool_ref.append(pool)
+
+        pool.reset()  # Pause the pool.
+        listener.reset()
+        with self.assertRaises(AutoReconnect):
+            with pool.checkout():
+                pass
+
+        self.assertEqual(
+            [True],
+            locked_while_emitting,
+            "ConnectionCheckOutFailedEvent must be published while the pool mutex is held",
+        )
+
     def test_no_wait_queue_timeout(self):
         # Verify get_socket() with no wait_queue_timeout blocks forever.
         pool = self.create_pool(max_pool_size=1)

--- a/test/test_pooling.py
+++ b/test/test_pooling.py
@@ -399,6 +399,24 @@ class TestPooling(_TestPoolingBase):
             f"Waited {duration:.2f} seconds for a socket, expected {wait_queue_timeout:f}",
         )
 
+    def test_wait_queue_timeout_does_not_leak_operation_count(self):
+        # Regression test: a checkout that fails while waiting for a pool
+        # slot must not leave operation_count permanently incremented.
+        wait_queue_timeout = 1  # Seconds
+        pool = self.create_pool(max_pool_size=1, wait_queue_timeout=wait_queue_timeout)
+        self.addCleanup(pool.close)
+
+        with pool.checkout():
+            self.assertEqual(pool.operation_count, 1)
+            with self.assertRaises(ConnectionFailure):
+                with pool.checkout():
+                    pass
+            # The failed second checkout must not have left operation_count
+            # incremented for its own (failed) attempt.
+            self.assertEqual(pool.operation_count, 1)
+
+        self.assertEqual(pool.operation_count, 0)
+
     def test_no_wait_queue_timeout(self):
         # Verify get_socket() with no wait_queue_timeout blocks forever.
         pool = self.create_pool(max_pool_size=1)

--- a/test/test_pooling.py
+++ b/test/test_pooling.py
@@ -32,10 +32,11 @@ from bson.son import SON
 from pymongo import MongoClient, message, timeout
 from pymongo.errors import AutoReconnect, ConnectionFailure, DuplicateKeyError
 from pymongo.hello import HelloCompat
-from pymongo.lock import _create_lock
+from pymongo.lock import _cond_wait, _create_lock
 from pymongo.monitoring import (
     ConnectionCheckOutFailedEvent,
     ConnectionCheckOutFailedReason,
+    PoolClearedEvent,
     _EventListeners,
 )
 from test.utils import flaky, get_pool, joinall
@@ -43,6 +44,7 @@ from test.utils import flaky, get_pool, joinall
 sys.path[0:0] = [""]
 
 from pymongo.socket_checker import SocketChecker
+from pymongo.synchronous import pool as pool_module
 from pymongo.synchronous.pool import Pool, PoolOptions
 from test import IntegrationTest, client_context, unittest
 from test.helpers import ConcurrentRunner
@@ -280,6 +282,7 @@ class TestPooling(_TestPoolingBase):
         # Bookkeeping must be rolled back, not left half-updated.
         self.assertEqual(0, cx_pool.active_sockets)
         self.assertEqual(0, cx_pool.requests)
+        self.assertEqual(0, cx_pool.operation_count)
 
     def test_pool_removes_closed_socket(self):
         # Test that Pool removes explicitly closed socket.
@@ -493,6 +496,88 @@ class TestPooling(_TestPoolingBase):
             [True],
             locked_while_emitting,
             "ConnectionCheckOutFailedEvent must be published while the pool mutex is held",
+        )
+
+    def test_checkout_failed_event_is_emitted_under_the_pool_lock_slow_path(self):
+        # Same guarantee as the test above, but for the readiness checks on
+        # the slow path. That test pauses an idle pool, so a slot is free and
+        # only the fast path runs; moving emission out from under the mutex in
+        # the slow path alone would not fail it. Here the pool's only slot is
+        # already taken, so the checkout blocks on size_cond, and reset()
+        # wakes it. This is exactly the PYTHON-3519 scenario: _reset()
+        # publishes PoolClearedEvent and calls notify_all() while holding the
+        # mutex, so the woken checkout can only publish its
+        # ConnectionCheckOutFailedEvent afterwards -- but only if it, too,
+        # publishes while still holding the mutex.
+        locked_while_emitting = []
+        pool_ref: list = []
+
+        class LockObservingListener(CMAPListener):
+            def connection_check_out_failed(self, event):
+                locked_while_emitting.append(pool_ref[0].lock.locked())
+                super().connection_check_out_failed(event)
+
+        listener = LockObservingListener()
+        pool = self.create_pool(max_pool_size=1, event_listeners=_EventListeners([listener]))
+        self.addCleanup(pool.close)
+        pool_ref.append(pool)
+
+        errors: list = []
+
+        def blocked_checkout():
+            try:
+                with pool.checkout():
+                    pass
+            except BaseException as exc:
+                errors.append(exc)
+
+        # The checkout must be parked on size_cond before the pool is reset,
+        # otherwise it could still fail on the fast path and this test would
+        # silently duplicate the one above. Flag it from inside the condition
+        # wait itself: the flag is set while size_cond is still held, so
+        # reset() cannot acquire the mutex until the checkout has released it
+        # by blocking.
+        parked: list = []
+        real_cond_wait = _cond_wait
+
+        def flagging_cond_wait(condition, timeout):
+            if condition is pool.size_cond:
+                parked.append(True)
+            return real_cond_wait(condition, timeout)
+
+        with patch.object(pool_module, "_cond_wait", flagging_cond_wait):
+            with pool.checkout():
+                listener.reset()
+                task = ConcurrentRunner(target=blocked_checkout, name="blocked_checkout")
+                task.start()
+
+                start = time.monotonic()
+                while not parked:  # noqa: ASYNC110, RUF100
+                    self.assertLess(
+                        time.monotonic() - start, 30, "checkout never blocked on size_cond"
+                    )
+                    time.sleep(0.01)
+
+                pool.reset()  # Pause the pool and wake the blocked checkout.
+                task.join(30)
+                self.assertFalse(task.is_alive(), "blocked checkout never finished")
+
+        self.assertEqual(1, len(errors), f"expected exactly one failed checkout, got {errors}")
+        self.assertIsInstance(errors[0], AutoReconnect)
+        self.assertEqual(
+            [True],
+            locked_while_emitting,
+            "ConnectionCheckOutFailedEvent must be published while the pool mutex is held",
+        )
+        # PYTHON-3519: the clear that caused the failure must be recorded first.
+        self.assertEqual(
+            [PoolClearedEvent, ConnectionCheckOutFailedEvent],
+            [
+                type(event)
+                for event in listener.events_by_type(
+                    (PoolClearedEvent, ConnectionCheckOutFailedEvent)
+                )
+            ],
         )
 
     def test_no_wait_queue_timeout(self):

--- a/test/test_topology.py
+++ b/test/test_topology.py
@@ -939,9 +939,14 @@ def create_mock_replica_set_topology(hosts=("a", "b", "c")):
 
 
 class TestTopologyDescriptionImmutability(TopologyTest):
-    """A TopologyDescription is shared by every concurrent selection call and
-    is replaced, not edited, when the topology changes (PYTHON-5898), so
-    apply_selector() must not mutate it.
+    """apply_selector() must not mutate the TopologyDescription (PYTHON-5898).
+
+    Deprioritization is specific to a single call, but the description outlives
+    it, so filtering left behind would leak into later readers such as
+    get_primary(), which builds its selection straight from the description.
+    The same object is also handed to code on other threads -- topology event
+    listeners and anything holding client.topology_description -- which may
+    read it concurrently with a selection in progress.
     """
 
     def test_concurrent_apply_selector_with_deprioritized_servers(self):
@@ -963,23 +968,33 @@ class TestTopologyDescriptionImmutability(TopologyTest):
         barrier = threading.Barrier(6)
 
         def deprioritizing_worker():
-            barrier.wait(timeout=30)
-            for _ in range(iterations):
-                # A retryable write retrying away from the primary must never
-                # be handed the deprioritized primary back.
-                sds = description.apply_selector(
-                    ReadPreference.PRIMARY_PREFERRED, deprioritized_servers=[primary_sd]
-                )
-                if any(sd.address == primary_sd.address for sd in sds):
-                    errors.append(f"deprioritized primary was selected: {sds}")
+            # Without this, threading would print an unexpected exception (a
+            # BrokenBarrierError from the barrier timeout, say) and discard it,
+            # leaving errors empty and passing the test vacuously.
+            try:
+                barrier.wait(timeout=30)
+                for _ in range(iterations):
+                    # A retryable write retrying away from the primary must
+                    # never be handed the deprioritized primary back.
+                    sds = description.apply_selector(
+                        ReadPreference.PRIMARY_PREFERRED, deprioritized_servers=[primary_sd]
+                    )
+                    if any(sd.address == primary_sd.address for sd in sds):
+                        errors.append(f"deprioritized primary was selected: {sds}")
+            except BaseException as exc:
+                errors.append(repr(exc))
 
         def plain_worker():
-            barrier.wait(timeout=30)
-            for _ in range(iterations):
-                # An ordinary operation must always find the healthy primary.
-                sds = description.apply_selector(Primary())
-                if [sd.address for sd in sds] != [primary_sd.address]:
-                    errors.append(f"Primary() selected {sds} instead of the primary")
+            try:
+                barrier.wait(timeout=30)
+                for _ in range(iterations):
+                    # An ordinary operation must always find the healthy
+                    # primary.
+                    sds = description.apply_selector(Primary())
+                    if [sd.address for sd in sds] != [primary_sd.address]:
+                        errors.append(f"Primary() selected {sds} instead of the primary")
+            except BaseException as exc:
+                errors.append(repr(exc))
 
         threads = [threading.Thread(target=deprioritizing_worker) for _ in range(3)]
         threads += [threading.Thread(target=plain_worker) for _ in range(3)]
@@ -1015,6 +1030,30 @@ class TestTopologyDescriptionImmutability(TopologyTest):
 
         # get_primary() must still find the primary afterwards.
         self.assertEqual(("a", 27017), t.get_primary())
+
+    def test_get_secondaries_after_deprioritized_selection(self):
+        # get_secondaries()/get_arbiters() (and client.secondaries/arbiters)
+        # also build their selection straight from the description, so a
+        # selection that deprioritizes a secondary must not drop it from a
+        # later membership listing.
+        t = create_mock_replica_set_topology()
+        self.addCleanup(t.close)
+        description = t.description
+        secondaries = {("b", 27017), ("c", 27017)}
+        secondary_sd = description.server_descriptions()[("b", 27017)]
+        self.assertEqual(SERVER_TYPE.RSSecondary, secondary_sd.server_type)
+
+        self.assertEqual(secondaries, t.get_secondaries())
+
+        # Simulate a retryable operation deprioritizing one secondary for a
+        # single selection call.
+        description.apply_selector(
+            ReadPreference.SECONDARY_PREFERRED, deprioritized_servers=[secondary_sd]
+        )
+
+        # Both secondaries must still be reported afterwards.
+        self.assertEqual(secondaries, t.get_secondaries())
+        self.assertEqual(set(), t.get_arbiters())
 
 
 if __name__ == "__main__":

--- a/test/test_topology.py
+++ b/test/test_topology.py
@@ -990,7 +990,9 @@ class TestTopologyDescriptionImmutability(TopologyTest):
 
         # Every selection must have returned its own correct result: no
         # worker was handed a server that another worker's concurrent call
-        # had filtered out, or should have filtered out.
+        # had filtered out, or should have filtered out. On failure the
+        # assertion output includes the first five error messages, and the
+        # custom message carries the true total.
         self.assertEqual([], errors[:5], f"{len(errors)} racy selections")
 
     def test_get_primary_after_deprioritized_selection(self):

--- a/test/test_topology.py
+++ b/test/test_topology.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import sys
+import threading
 
 from pymongo.operations import _Op
 
@@ -905,6 +906,102 @@ class TestServerSelectionErrors(TopologyTest):
         got_hello(t, ("a", 27017), {"ok": 1})
         got_hello(t, ("b", 27017), {"ok": 1})
         self.assertMessage("No mongoses available", t)
+
+
+def create_mock_replica_set_topology(hosts=("a", "b", "c")):
+    """A ReplicaSetWithPrimary topology: hosts[0] is primary, the rest secondary."""
+    t = create_mock_topology(seeds=list(hosts), replica_set_name="rs")
+    got_hello(
+        t,
+        (hosts[0], 27017),
+        {
+            "ok": 1,
+            HelloCompat.LEGACY_CMD: True,
+            "setName": "rs",
+            "hosts": list(hosts),
+            "maxWireVersion": common.MIN_SUPPORTED_WIRE_VERSION,
+        },
+    )
+    for host in hosts[1:]:
+        got_hello(
+            t,
+            (host, 27017),
+            {
+                "ok": 1,
+                HelloCompat.LEGACY_CMD: False,
+                "secondary": True,
+                "setName": "rs",
+                "hosts": list(hosts),
+                "maxWireVersion": common.MIN_SUPPORTED_WIRE_VERSION,
+            },
+        )
+    return t
+
+
+class TestTopologyDescriptionConcurrency(TopologyTest):
+    """apply_selector() runs under a shared read lock (PYTHON-5898), so it must
+    not mutate the TopologyDescription: concurrent callers passing different
+    deprioritized_servers would otherwise clobber each other's candidate lists.
+    """
+
+    def test_concurrent_apply_selector_with_deprioritized_servers(self):
+        t = create_mock_replica_set_topology()
+        self.addCleanup(t.close)
+        description = t.description
+        self.assertEqual(TOPOLOGY_TYPE.ReplicaSetWithPrimary, description.topology_type)
+        primary_sd = description.server_descriptions()[("a", 27017)]
+        self.assertEqual(SERVER_TYPE.RSPrimary, primary_sd.server_type)
+
+        # Make the interpreter switch threads aggressively so a mutation race
+        # inside apply_selector() is caught reliably rather than occasionally.
+        old_interval = sys.getswitchinterval()
+        sys.setswitchinterval(1e-6)
+        self.addCleanup(sys.setswitchinterval, old_interval)
+
+        iterations = 500
+        errors: list[str] = []
+        barrier = threading.Barrier(6)
+
+        def deprioritizing_worker():
+            barrier.wait()
+            for _ in range(iterations):
+                # A retryable write retrying away from the primary must never
+                # be handed the deprioritized primary back.
+                sds = description.apply_selector(
+                    ReadPreference.PRIMARY_PREFERRED, deprioritized_servers=[primary_sd]
+                )
+                if any(sd.address == primary_sd.address for sd in sds):
+                    errors.append(f"deprioritized primary was selected: {sds}")
+
+        def plain_worker():
+            barrier.wait()
+            for _ in range(iterations):
+                # An ordinary operation must always find the healthy primary.
+                sds = description.apply_selector(Primary())
+                if [sd.address for sd in sds] != [primary_sd.address]:
+                    errors.append(f"Primary() selected {sds} instead of the primary")
+
+        threads = [threading.Thread(target=deprioritizing_worker) for _ in range(3)]
+        threads += [threading.Thread(target=plain_worker) for _ in range(3)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        self.assertEqual([], errors[:5], f"{len(errors)} racy selections")
+
+    def test_apply_selector_does_not_mutate_description(self):
+        t = create_mock_replica_set_topology()
+        self.addCleanup(t.close)
+        description = t.description
+        primary_sd = description.server_descriptions()[("a", 27017)]
+
+        before = list(description.candidate_servers)
+        description.apply_selector(
+            ReadPreference.PRIMARY_PREFERRED, deprioritized_servers=[primary_sd]
+        )
+        self.assertEqual(before, description.candidate_servers)
+        self.assertIn(primary_sd, description.candidate_servers)
 
 
 if __name__ == "__main__":

--- a/test/test_topology.py
+++ b/test/test_topology.py
@@ -939,11 +939,10 @@ def create_mock_replica_set_topology(hosts=("a", "b", "c")):
 
 
 class TestTopologyDescriptionImmutability(TopologyTest):
-    """TopologyDescription is a shared, publicly-exposed immutable snapshot
-    (PYTHON-5898), so apply_selector() must not mutate it: caching a per-call
-    filtered candidate list on the description would leave the public
-    candidate_servers property permanently stale after any selection that
-    deprioritized servers.
+    """A TopologyDescription is shared by every concurrent selection call and
+    is replaced, not edited, when the topology changes (PYTHON-5898). So
+    apply_selector() must not mutate it: caching a per-call filtered candidate
+    list on the description outlived the call that produced it.
     """
 
     def test_concurrent_apply_selector_with_deprioritized_servers(self):
@@ -994,13 +993,12 @@ class TestTopologyDescriptionImmutability(TopologyTest):
 
     def test_get_primary_after_deprioritized_selection(self):
         # Regression test for PYTHON-5898 / PYTHON-5662: apply_selector()
-        # used to cache its filtered candidate list on the (shared, publicly
-        # exposed) TopologyDescription, so candidate_servers stayed stale
-        # after any selection that deprioritized a server. get_primary()
-        # (and client.primary) build their selection from candidate_servers,
-        # so a stale, primary-less candidate list made
-        # writable_server_selector(...)[0] raise IndexError even though the
-        # primary was still known and healthy.
+        # used to cache its filtered candidate list on the shared
+        # TopologyDescription, so the filtering outlived the call that
+        # produced it. get_primary() (and client.primary) build their
+        # selection straight from the description, so a stale, primary-less
+        # candidate list made writable_server_selector(...)[0] raise
+        # IndexError even though the primary was still known and healthy.
         t = create_mock_replica_set_topology()
         self.addCleanup(t.close)
         description = t.description
@@ -1018,24 +1016,6 @@ class TestTopologyDescriptionImmutability(TopologyTest):
         # get_primary() must still find the primary afterwards; it must not
         # raise IndexError because of a stale, primary-less candidate list.
         self.assertEqual(("a", 27017), t.get_primary())
-
-    def test_apply_selector_does_not_mutate_description(self):
-        t = create_mock_replica_set_topology()
-        self.addCleanup(t.close)
-        description = t.description
-        primary_sd = description.server_descriptions()[("a", 27017)]
-
-        # A selection that deprioritizes the primary must not leave that
-        # filtering behind on the description: a later selection with nothing
-        # deprioritized has to see the primary again.
-        before = list(description.known_servers)
-        description.apply_selector(
-            ReadPreference.PRIMARY_PREFERRED, deprioritized_servers=[primary_sd]
-        )
-        self.assertEqual(before, description.known_servers)
-
-        after = description.apply_selector(ReadPreference.PRIMARY_PREFERRED)
-        self.assertIn(primary_sd, after)
 
 
 if __name__ == "__main__":

--- a/test/test_topology.py
+++ b/test/test_topology.py
@@ -988,6 +988,9 @@ class TestTopologyDescriptionImmutability(TopologyTest):
         for thread in threads:
             thread.join()
 
+        # Every selection must have returned its own correct result: no
+        # worker was handed a server that another worker's concurrent call
+        # had filtered out, or should have filtered out.
         self.assertEqual([], errors[:5], f"{len(errors)} racy selections")
 
     def test_get_primary_after_deprioritized_selection(self):

--- a/test/test_topology.py
+++ b/test/test_topology.py
@@ -1025,12 +1025,17 @@ class TestTopologyDescriptionImmutability(TopologyTest):
         description = t.description
         primary_sd = description.server_descriptions()[("a", 27017)]
 
-        before = list(description.candidate_servers)
+        # A selection that deprioritizes the primary must not leave that
+        # filtering behind on the description: a later selection with nothing
+        # deprioritized has to see the primary again.
+        before = list(description.known_servers)
         description.apply_selector(
             ReadPreference.PRIMARY_PREFERRED, deprioritized_servers=[primary_sd]
         )
-        self.assertEqual(before, description.candidate_servers)
-        self.assertIn(primary_sd, description.candidate_servers)
+        self.assertEqual(before, description.known_servers)
+
+        after = description.apply_selector(ReadPreference.PRIMARY_PREFERRED)
+        self.assertIn(primary_sd, after)
 
 
 if __name__ == "__main__":

--- a/test/test_topology.py
+++ b/test/test_topology.py
@@ -938,10 +938,12 @@ def create_mock_replica_set_topology(hosts=("a", "b", "c")):
     return t
 
 
-class TestTopologyDescriptionConcurrency(TopologyTest):
-    """apply_selector() runs under a shared read lock (PYTHON-5898), so it must
-    not mutate the TopologyDescription: concurrent callers passing different
-    deprioritized_servers would otherwise clobber each other's candidate lists.
+class TestTopologyDescriptionImmutability(TopologyTest):
+    """TopologyDescription is a shared, publicly-exposed immutable snapshot
+    (PYTHON-5898), so apply_selector() must not mutate it: caching a per-call
+    filtered candidate list on the description would leave the public
+    candidate_servers property permanently stale after any selection that
+    deprioritized servers.
     """
 
     def test_concurrent_apply_selector_with_deprioritized_servers(self):
@@ -963,7 +965,7 @@ class TestTopologyDescriptionConcurrency(TopologyTest):
         barrier = threading.Barrier(6)
 
         def deprioritizing_worker():
-            barrier.wait()
+            barrier.wait(timeout=30)
             for _ in range(iterations):
                 # A retryable write retrying away from the primary must never
                 # be handed the deprioritized primary back.
@@ -974,7 +976,7 @@ class TestTopologyDescriptionConcurrency(TopologyTest):
                     errors.append(f"deprioritized primary was selected: {sds}")
 
         def plain_worker():
-            barrier.wait()
+            barrier.wait(timeout=30)
             for _ in range(iterations):
                 # An ordinary operation must always find the healthy primary.
                 sds = description.apply_selector(Primary())
@@ -989,6 +991,33 @@ class TestTopologyDescriptionConcurrency(TopologyTest):
             thread.join()
 
         self.assertEqual([], errors[:5], f"{len(errors)} racy selections")
+
+    def test_get_primary_after_deprioritized_selection(self):
+        # Regression test for PYTHON-5898 / PYTHON-5662: apply_selector()
+        # used to cache its filtered candidate list on the (shared, publicly
+        # exposed) TopologyDescription, so candidate_servers stayed stale
+        # after any selection that deprioritized a server. get_primary()
+        # (and client.primary) build their selection from candidate_servers,
+        # so a stale, primary-less candidate list made
+        # writable_server_selector(...)[0] raise IndexError even though the
+        # primary was still known and healthy.
+        t = create_mock_replica_set_topology()
+        self.addCleanup(t.close)
+        description = t.description
+        primary_sd = description.server_descriptions()[("a", 27017)]
+        self.assertEqual(SERVER_TYPE.RSPrimary, primary_sd.server_type)
+
+        self.assertEqual(("a", 27017), t.get_primary())
+
+        # Simulate a retryable operation deprioritizing the primary for one
+        # selection call.
+        description.apply_selector(
+            ReadPreference.PRIMARY_PREFERRED, deprioritized_servers=[primary_sd]
+        )
+
+        # get_primary() must still find the primary afterwards; it must not
+        # raise IndexError because of a stale, primary-less candidate list.
+        self.assertEqual(("a", 27017), t.get_primary())
 
     def test_apply_selector_does_not_mutate_description(self):
         t = create_mock_replica_set_topology()

--- a/test/test_topology.py
+++ b/test/test_topology.py
@@ -908,9 +908,14 @@ class TestServerSelectionErrors(TopologyTest):
         self.assertMessage("No mongoses available", t)
 
 
-def create_mock_replica_set_topology(hosts=("a", "b", "c")):
-    """A ReplicaSetWithPrimary topology: hosts[0] is primary, the rest secondary."""
-    t = create_mock_topology(seeds=list(hosts), replica_set_name="rs")
+def create_mock_replica_set_topology(hosts=("a", "b", "c"), arbiters=()):
+    """A ReplicaSetWithPrimary topology: hosts[0] is primary, the rest secondary.
+
+    Any names in ``arbiters`` join the set as arbiters.
+    """
+    arbiters = list(arbiters)
+    members = {"hosts": list(hosts), "arbiters": arbiters}
+    t = create_mock_topology(seeds=list(hosts) + arbiters, replica_set_name="rs")
     got_hello(
         t,
         (hosts[0], 27017),
@@ -918,8 +923,8 @@ def create_mock_replica_set_topology(hosts=("a", "b", "c")):
             "ok": 1,
             HelloCompat.LEGACY_CMD: True,
             "setName": "rs",
-            "hosts": list(hosts),
             "maxWireVersion": common.MIN_SUPPORTED_WIRE_VERSION,
+            **members,
         },
     )
     for host in hosts[1:]:
@@ -931,8 +936,21 @@ def create_mock_replica_set_topology(hosts=("a", "b", "c")):
                 HelloCompat.LEGACY_CMD: False,
                 "secondary": True,
                 "setName": "rs",
-                "hosts": list(hosts),
                 "maxWireVersion": common.MIN_SUPPORTED_WIRE_VERSION,
+                **members,
+            },
+        )
+    for arbiter in arbiters:
+        got_hello(
+            t,
+            (arbiter, 27017),
+            {
+                "ok": 1,
+                HelloCompat.LEGACY_CMD: False,
+                "arbiterOnly": True,
+                "setName": "rs",
+                "maxWireVersion": common.MIN_SUPPORTED_WIRE_VERSION,
+                **members,
             },
         )
     return t
@@ -1036,24 +1054,29 @@ class TestTopologyDescriptionImmutability(TopologyTest):
         # also build their selection straight from the description, so a
         # selection that deprioritizes a secondary must not drop it from a
         # later membership listing.
-        t = create_mock_replica_set_topology()
+        t = create_mock_replica_set_topology(arbiters=("d",))
         self.addCleanup(t.close)
         description = t.description
         secondaries = {("b", 27017), ("c", 27017)}
+        arbiters = {("d", 27017)}
         secondary_sd = description.server_descriptions()[("b", 27017)]
         self.assertEqual(SERVER_TYPE.RSSecondary, secondary_sd.server_type)
+        arbiter_sd = description.server_descriptions()[("d", 27017)]
+        self.assertEqual(SERVER_TYPE.RSArbiter, arbiter_sd.server_type)
 
         self.assertEqual(secondaries, t.get_secondaries())
+        self.assertEqual(arbiters, t.get_arbiters())
 
-        # Simulate a retryable operation deprioritizing one secondary for a
-        # single selection call.
+        # Simulate a retryable operation deprioritizing one secondary and the
+        # arbiter for a single selection call.
         description.apply_selector(
-            ReadPreference.SECONDARY_PREFERRED, deprioritized_servers=[secondary_sd]
+            ReadPreference.SECONDARY_PREFERRED,
+            deprioritized_servers=[secondary_sd, arbiter_sd],
         )
 
-        # Both secondaries must still be reported afterwards.
+        # Both secondaries and the arbiter must still be reported afterwards.
         self.assertEqual(secondaries, t.get_secondaries())
-        self.assertEqual(set(), t.get_arbiters())
+        self.assertEqual(arbiters, t.get_arbiters())
 
 
 if __name__ == "__main__":

--- a/test/test_topology.py
+++ b/test/test_topology.py
@@ -940,9 +940,8 @@ def create_mock_replica_set_topology(hosts=("a", "b", "c")):
 
 class TestTopologyDescriptionImmutability(TopologyTest):
     """A TopologyDescription is shared by every concurrent selection call and
-    is replaced, not edited, when the topology changes (PYTHON-5898). So
-    apply_selector() must not mutate it: caching a per-call filtered candidate
-    list on the description outlived the call that produced it.
+    is replaced, not edited, when the topology changes (PYTHON-5898), so
+    apply_selector() must not mutate it.
     """
 
     def test_concurrent_apply_selector_with_deprioritized_servers(self):
@@ -992,13 +991,9 @@ class TestTopologyDescriptionImmutability(TopologyTest):
         self.assertEqual([], errors[:5], f"{len(errors)} racy selections")
 
     def test_get_primary_after_deprioritized_selection(self):
-        # Regression test for PYTHON-5898 / PYTHON-5662: apply_selector()
-        # used to cache its filtered candidate list on the shared
-        # TopologyDescription, so the filtering outlived the call that
-        # produced it. get_primary() (and client.primary) build their
-        # selection straight from the description, so a stale, primary-less
-        # candidate list made writable_server_selector(...)[0] raise
-        # IndexError even though the primary was still known and healthy.
+        # get_primary() (and client.primary) build their selection straight
+        # from the description, so a selection that deprioritizes the primary
+        # must not stop a later get_primary() from finding it.
         t = create_mock_replica_set_topology()
         self.addCleanup(t.close)
         description = t.description
@@ -1013,8 +1008,7 @@ class TestTopologyDescriptionImmutability(TopologyTest):
             ReadPreference.PRIMARY_PREFERRED, deprioritized_servers=[primary_sd]
         )
 
-        # get_primary() must still find the primary afterwards; it must not
-        # raise IndexError because of a stale, primary-less candidate list.
+        # get_primary() must still find the primary afterwards.
         self.assertEqual(("a", 27017), t.get_primary())
 
 


### PR DESCRIPTION

## Changes in this PR

- Reduced the number of pool lock acquisitions on the connection checkout fast
  path. The contended path is unchanged.
- Kept checkout-failed events published while holding the pool lock, preserving
  the ordering guarantee from PYTHON-3519.
- Fixed `client.primary` raising `IndexError`, and `client.secondaries` and
  `client.arbiters` returning stale results, after a retryable operation
  deprioritized the primary. Regression from PYTHON-5662.
- **Breaking:** removed `TopologyDescription.candidate_servers`, added in
  4.16.0. Its value depended on which selection call ran last. `known_servers`
  is the direct replacement and is already public.
- Fixed a leak, present since PYTHON-2395, where a failed checkout permanently
  incremented a pool's `operation_count`, so an affected mongos was
  progressively avoided by server selection.

### Not pursued: the proposed Topology reader/writer lock

The ticket also proposed giving `Topology` a reader/writer lock. That was
implemented and then reverted: it made server selection about 30% slower at
concurrency 20 in every case measured, including topology churn.

Measuring the premise directly, under real operations rather than a tight
selection loop, the topology lock turns out not to be contended. Time spent
blocked waiting for it, as a share of aggregate worker time:

| concurrency | throughput | lock wait | mean wait per acquire |
|---|---|---|---|
| 20 | 8,052 ops/s | 0.016% | 0.20 us |
| 50 | 7,863 ops/s | 0.006% | 0.18 us |
| 100 | 7,673 ops/s | 0.003% | 0.18 us |

Contention falls as concurrency rises, and the mean wait per acquire stays at
roughly the cost of an uncontended acquire. Measured against localhost, where
the lock's share of total time is as large as it will ever be.

The ceiling on optimizing this lock is about 0.016% throughput, for any
approach. Suggest recording that on the ticket and dropping the work from its
scope.

## Test Plan

Nine new tests. Each was run against the unfixed code and confirmed to fail
there, then against the fix and confirmed to pass:

- three covering the selection bug, including a threaded one and the
  `client.primary`, `client.secondaries` and `client.arbiters` symptoms
- four covering the `operation_count` leak and checkout-failed event behaviour,
  on both the fast and the contended checkout path
- two pinning the number of pool lock acquisitions a checkout makes, so the
  reduction cannot be undone unnoticed

To confirm the selection change is otherwise behavior-preserving, selection
output was captured before and after across every server-selection and
max-staleness fixture, nine selectors, and every subset of deprioritized
servers. Results are identical apart from the `client.primary` calls that
previously raised.

Clean runs of the topology, server-selection, pool, connection-monitoring, and
SDAM suites, in both the async and sync flavours. `just synchro` produces no
drift, `just typing` reports 0 errors, `just lint-manual` passes.

Checkout throughput at concurrency 20 is up 6.6%; server selection is unchanged.

Two pre-existing issues surfaced, neither introduced here:

- Running the topology, pool, and connection-monitoring suites in one pytest
  process produces order-dependent `TestPoolMaxSize` failures on this branch and
  on unmodified main, a different set each time. All pass in isolation.
- The CMAP harness's `check_events` only fails on missing events and silently
  tolerates extra ones, so duplicate events can pass unnoticed.

## Checklist

### Checklist for Author
- [x] Did you update the changelog (if necessary)? Four entries under 4.18.0.
- [x] Is there test coverage? Nine new tests, each confirmed failing pre-fix.
- [x] Is any followup work tracked in a JIRA ticket? If so, add link(s).
      PYTHON-5982 adds a concurrent checkout benchmark to the performance suite,
      so a regression like the reader/writer lock's would be caught in CI.
      Still to file: update PYTHON-5898 to drop the topology lock work from
      scope; the two test issues above; deprioritization applies only to the
      first attempt of a selection (from PYTHON-5662); and `tools/synchro.py`'s
      `"aiter": "iter"` replacement is not word-boundary aware, so it silently
      corrupts any identifier or comment containing "waiter".
