### PR TITLE
PYTHON-5805 CSFLE/QE Support for HTTP Proxies

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -45,11 +45,9 @@ PyMongo 4.18 brings a number of changes including:
   :class:`~pymongo.encryption_options.AutoEncryptionOpts`,
   :class:`~pymongo.encryption.ClientEncryption`, and
   :class:`~pymongo.asynchronous.encryption.AsyncClientEncryption`. The callback
-  opens the connection to the KMS host and the driver performs the KMS TLS
-  handshake over it, so certificate and hostname verification continue to
-  target the KMS host rather than the proxy. See
-  :class:`~pymongo.encryption_options.KMSConnectContext` for an HTTP
-  ``CONNECT`` example.
+  opens the connection and the driver performs the KMS TLS handshake over it, so
+  verification still targets the KMS host rather than the proxy. See
+  :class:`~pymongo.encryption_options.KMSConnectContext` for an example.
 
 Changes in Version 4.17.0 (2026/04/20)
 --------------------------------------

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -39,6 +39,17 @@ PyMongo 4.18 brings a number of changes including:
 - Fixed a bug on Windows, and on macOS when using PyOpenSSL, where
   ``SSL_CERT_FILE``/``SSL_CERT_DIR`` were merged with, rather than replacing,
   the OS/certifi certificate store.
+- Added support for routing Key Management Service (KMS) requests for
+  Client-Side Field Level Encryption and Queryable Encryption through an HTTP
+  proxy, using the new ``kms_connect_callback`` option on
+  :class:`~pymongo.encryption_options.AutoEncryptionOpts`,
+  :class:`~pymongo.encryption.ClientEncryption`, and
+  :class:`~pymongo.asynchronous.encryption.AsyncClientEncryption`. The callback
+  opens the connection to the KMS host and the driver performs the KMS TLS
+  handshake over it, so certificate and hostname verification continue to
+  target the KMS host rather than the proxy. See
+  :class:`~pymongo.encryption_options.KMSConnectContext` for an HTTP
+  ``CONNECT`` example.
 
 Changes in Version 4.17.0 (2026/04/20)
 --------------------------------------

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -46,8 +46,10 @@ PyMongo 4.18 brings a number of changes including:
   :class:`~pymongo.encryption.ClientEncryption`, and
   :class:`~pymongo.asynchronous.encryption.AsyncClientEncryption`. The callback
   opens the connection and the driver performs the KMS TLS handshake over it, so
-  verification still targets the KMS host rather than the proxy. See
-  :class:`~pymongo.encryption_options.KMSConnectContext` for an example.
+  verification still targets the KMS host rather than the proxy. For an ordinary
+  HTTP proxy, pass :class:`~pymongo.encryption_options.HTTPProxyKMSConnect` or
+  :class:`~pymongo.encryption_options.AsyncHTTPProxyKMSConnect` instead of
+  writing a callback.
 
 Changes in Version 4.17.0 (2026/04/20)
 --------------------------------------

--- a/pymongo/asynchronous/encryption.py
+++ b/pymongo/asynchronous/encryption.py
@@ -142,8 +142,7 @@ async def _connect_kms(
         except Exception as exc:
             _raise_connection_failure(address, exc, timeout_details=_get_timeout_details(opts))
 
-    # TLS is applied here, against address, so verification targets the KMS
-    # host even when the socket terminates at a proxy.
+    # TLS targets address, not the peer, so verification follows the KMS host.
     result = kms_connect_callback(
         KMSConnectContext(host=address[0], port=cast(int, address[1]), timeout=timeout)
     )

--- a/pymongo/asynchronous/encryption.py
+++ b/pymongo/asynchronous/encryption.py
@@ -117,14 +117,6 @@ _DATA_KEY_OPTS: CodecOptions[dict[str, Any]] = CodecOptions(
 _KEY_VAULT_OPTS = CodecOptions(document_class=RawBSONDocument)
 
 
-class _KMSCallbackContractError(Exception):
-    """Raised when a kms_connect_callback violates its contract.
-
-    Unlike a network error from the callback, this is a programming error, so
-    it is never retried.
-    """
-
-
 def _close_rejected_kms_socket(obj: Any) -> None:
     """Close a rejected kms_connect_callback return value, if it can be closed.
 
@@ -160,19 +152,14 @@ async def _connect_kms(
     # function is the correct thing to pass and nothing is awaited.
     if not _IS_SYNC and not inspect.isawaitable(result):
         _close_rejected_kms_socket(result)
-        # "async" and "def" are deliberately split across the next two source
-        # lines: tools/synchro.py deletes "async " from any line that spells
-        # those two words together, which would garble this message in the
-        # generated synchronous file even though the branch never runs there.
-        raise _KMSCallbackContractError(
-            "kms_connect_callback must be a coroutine function (an 'async"
-            " def') for the async driver, but calling it returned "
-            f"{type(result)}, which is not awaitable."
+        raise ConfigurationError(
+            "kms_connect_callback must be a coroutine function for the async "
+            f"API, but calling it returned {type(result)}, which is not awaitable."
         )
     sock = await result
     if not isinstance(sock, socket.socket) or isinstance(sock, ssl.SSLSocket):
         _close_rejected_kms_socket(sock)
-        raise _KMSCallbackContractError(
+        raise ConfigurationError(
             "kms_connect_callback must return a connected, unwrapped "
             f"socket.socket, not {type(sock)}. TLS cannot be layered over an "
             "already-wrapped socket; to reach the proxy over TLS, relay through "
@@ -303,7 +290,7 @@ class _EncryptionIO(AsyncMongoCryptCallback):  # type: ignore[misc]
                 conn.close()
         except MongoCryptError:
             raise  # Propagate MongoCryptError errors directly.
-        except _KMSCallbackContractError:
+        except ConfigurationError:
             raise  # A callback contract violation is not transient.
         except Exception as exc:
             remaining = _csot.remaining()
@@ -742,7 +729,7 @@ class AsyncClientEncryption(Generic[_DocumentType]):
             KMS host, used to route KMS requests through an HTTP proxy. It
             receives a :class:`~pymongo.encryption_options.KMSConnectContext`
             and returns a connected, unwrapped :class:`socket.socket`; the
-            driver then performs the KMS TLS handshake over it. Must be a coroutine function.
+            driver then performs the KMS TLS handshake over it.
             See :class:`~pymongo.encryption_options.KMSConnectContext` for a worked
             HTTP ``CONNECT`` example. Defaults to ``None``, meaning the driver
             connects to KMS hosts directly.

--- a/pymongo/asynchronous/encryption.py
+++ b/pymongo/asynchronous/encryption.py
@@ -165,6 +165,10 @@ async def _connect_kms(
             "already-wrapped socket; to reach the proxy over TLS, relay through "
             "a socket.socketpair and return the plain end."
         )
+    # ssl.SSLContext.wrap_socket refuses a non-blocking socket, and a callback
+    # has no reason to care which mode it left the socket in, so normalize it
+    # here rather than pushing the requirement onto the caller.
+    sock.settimeout(opts.socket_timeout)
     try:
         return await _async_wrap_socket_tls(sock, address, opts)
     except Exception as exc:

--- a/pymongo/asynchronous/encryption.py
+++ b/pymongo/asynchronous/encryption.py
@@ -639,6 +639,7 @@ class AsyncClientEncryption(Generic[_DocumentType]):
         codec_options: CodecOptions[_DocumentTypeArg],
         kms_tls_options: Optional[Mapping[str, Any]] = None,
         key_expiration_ms: Optional[int] = None,
+        kms_connect_callback: Optional[AsyncKMSConnectCallback] = None,
     ) -> None:
         """Explicit client-side field level encryption.
 
@@ -708,7 +709,18 @@ class AsyncClientEncryption(Generic[_DocumentType]):
         :param key_expiration_ms: The cache expiration time for data encryption keys.
             Defaults to ``None`` which defers to libmongocrypt's default which is currently 60000.
             Set to 0 to disable key expiration.
+        :param kms_connect_callback: A callable that opens the connection to a
+            KMS host, used to route KMS requests through an HTTP proxy. It
+            receives a :class:`~pymongo.encryption_options.KMSConnectContext`
+            and returns a connected, unwrapped :class:`socket.socket`; the
+            driver then performs the KMS TLS handshake over it. Must be a
+            coroutine function. See
+            :class:`~pymongo.encryption_options.KMSConnectContext` for a worked
+            HTTP ``CONNECT`` example. Defaults to ``None``, meaning the driver
+            connects to KMS hosts directly.
 
+        .. versionchanged:: 4.18
+           Added the `kms_connect_callback` parameter.
         .. versionchanged:: 4.12
            Added the `key_expiration_ms` parameter.
         .. versionchanged:: 4.0
@@ -752,6 +764,7 @@ class AsyncClientEncryption(Generic[_DocumentType]):
             key_vault_namespace,
             kms_tls_options=kms_tls_options,
             key_expiration_ms=key_expiration_ms,
+            kms_connect_callback=kms_connect_callback,
         )
         self._kms_ssl_contexts = _parse_kms_tls_options(opts._kms_tls_options, _IS_SYNC)
         self._io_callbacks: Optional[_EncryptionIO] = _EncryptionIO(

--- a/pymongo/asynchronous/encryption.py
+++ b/pymongo/asynchronous/encryption.py
@@ -148,7 +148,7 @@ async def _connect_kms(
     result = kms_connect_callback(
         KMSConnectContext(host=address[0], port=cast(int, address[1]), timeout=timeout)
     )
-    # _IS_SYNC is True in the generated synchronous flavor, where a regular
+    # _IS_SYNC is True in the generated synchronous module, where a regular
     # function is the correct thing to pass and nothing is awaited.
     if not _IS_SYNC and not inspect.isawaitable(result):
         _close_rejected_kms_socket(result)

--- a/pymongo/asynchronous/encryption.py
+++ b/pymongo/asynchronous/encryption.py
@@ -161,12 +161,9 @@ async def _connect_kms(
         _close_rejected_kms_socket(sock)
         raise ConfigurationError(
             "kms_connect_callback must return a connected, unwrapped "
-            f"socket.socket, not {type(sock)}. An asyncio stream or transport, "
-            "including the object from transport.get_extra_info('socket'), "
-            "cannot be used; connect with loop.sock_connect instead. TLS cannot "
-            "be layered over an already-wrapped socket either; to reach the "
-            "proxy over TLS, relay through a socket.socketpair and return the "
-            "plain end."
+            f"socket.socket, not {type(sock)}. Streams, transports and "
+            "transport sockets cannot be used; try loop.sock_connect. For a "
+            "TLS proxy, relay through a socket.socketpair and return the plain end."
         )
     # ssl.SSLContext.wrap_socket refuses a non-blocking socket, and a callback
     # has no reason to care which mode it left the socket in, so normalize it

--- a/pymongo/asynchronous/encryption.py
+++ b/pymongo/asynchronous/encryption.py
@@ -20,6 +20,7 @@ import asyncio
 import contextlib
 import enum
 import socket
+import ssl
 import time as time  # noqa: PLC0414 # needed in sync version
 import uuid
 import weakref
@@ -63,7 +64,9 @@ from pymongo.asynchronous.mongo_client import AsyncMongoClient
 from pymongo.common import CONNECT_TIMEOUT
 from pymongo.daemon import _spawn_daemon
 from pymongo.encryption_options import (
+    AsyncKMSConnectCallback,
     AutoEncryptionOpts,
+    KMSConnectContext,
     RangeOpts,
     TextOpts,
     check_min_pymongocrypt,
@@ -82,6 +85,7 @@ from pymongo.operations import UpdateOne
 from pymongo.pool_options import PoolOptions
 from pymongo.pool_shared import (
     _async_configured_socket,
+    _async_wrap_socket_tls,
     _raise_connection_failure,
 )
 from pymongo.read_concern import ReadConcern
@@ -112,9 +116,41 @@ _DATA_KEY_OPTS: CodecOptions[dict[str, Any]] = CodecOptions(
 _KEY_VAULT_OPTS = CodecOptions(document_class=RawBSONDocument)
 
 
-async def _connect_kms(address: _Address, opts: PoolOptions) -> Union[socket.socket, _sslConn]:
+class _KMSCallbackContractError(Exception):
+    """Raised when a kms_connect_callback violates its contract.
+
+    Unlike a network error from the callback, this is a programming error, so
+    it is never retried.
+    """
+
+
+async def _connect_kms(
+    address: _Address,
+    opts: PoolOptions,
+    kms_connect_callback: Optional[AsyncKMSConnectCallback] = None,
+    timeout: Optional[float] = None,
+) -> Union[socket.socket, _sslConn]:
+    if kms_connect_callback is None:
+        try:
+            return await _async_configured_socket(address, opts)
+        except Exception as exc:
+            _raise_connection_failure(address, exc, timeout_details=_get_timeout_details(opts))
+
+    # Let the caller open the connection, then apply TLS ourselves so that SNI
+    # and certificate verification still target the KMS host even when the
+    # socket actually terminates at a proxy.
+    sock = await kms_connect_callback(
+        KMSConnectContext(host=address[0], port=cast(int, address[1]), timeout=timeout)
+    )
+    if not isinstance(sock, socket.socket) or isinstance(sock, ssl.SSLSocket):
+        raise _KMSCallbackContractError(
+            "kms_connect_callback must return a connected, unwrapped "
+            f"socket.socket, not {type(sock)}. TLS cannot be layered over an "
+            "already-wrapped socket; to reach the proxy over TLS, relay through "
+            "a socket.socketpair and return the plain end."
+        )
     try:
-        return await _async_configured_socket(address, opts)
+        return await _async_wrap_socket_tls(sock, address, opts)
     except Exception as exc:
         _raise_connection_failure(address, exc, timeout_details=_get_timeout_details(opts))
 
@@ -197,7 +233,12 @@ class _EncryptionIO(AsyncMongoCryptCallback):  # type: ignore[misc]
             sleep_sec = float(sleep_u) / 1e6
             await asyncio.sleep(sleep_sec)
         try:
-            conn = await _connect_kms(address, opts)
+            conn = await _connect_kms(
+                address,
+                opts,
+                self.opts._kms_connect_callback,
+                connect_timeout,
+            )
             try:
                 await async_socket_sendall(conn, message)
                 while kms_context.bytes_needed > 0:
@@ -233,6 +274,8 @@ class _EncryptionIO(AsyncMongoCryptCallback):  # type: ignore[misc]
                 conn.close()
         except MongoCryptError:
             raise  # Propagate MongoCryptError errors directly.
+        except _KMSCallbackContractError:
+            raise  # A callback contract violation is not transient.
         except Exception as exc:
             remaining = _csot.remaining()
             if isinstance(exc, NetworkTimeout) or (remaining is not None and remaining <= 0):

--- a/pymongo/asynchronous/encryption.py
+++ b/pymongo/asynchronous/encryption.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import enum
+import inspect
 import socket
 import ssl
 import time as time  # noqa: PLC0414 # needed in sync version
@@ -124,6 +125,19 @@ class _KMSCallbackContractError(Exception):
     """
 
 
+def _close_rejected_kms_socket(obj: Any) -> None:
+    """Close a rejected kms_connect_callback return value, if it can be closed.
+
+    The caller may have handed us a live socket, and nothing else will close it:
+    _connect_kms raises before its result reaches the caller's ``finally``. The
+    value can be anything a user returned, so closing is strictly best effort.
+    """
+    close = getattr(obj, "close", None)
+    if callable(close):
+        with contextlib.suppress(Exception):
+            close()
+
+
 async def _connect_kms(
     address: _Address,
     opts: PoolOptions,
@@ -139,10 +153,25 @@ async def _connect_kms(
     # Let the caller open the connection, then apply TLS ourselves so that SNI
     # and certificate verification still target the KMS host even when the
     # socket actually terminates at a proxy.
-    sock = await kms_connect_callback(
+    result = kms_connect_callback(
         KMSConnectContext(host=address[0], port=cast(int, address[1]), timeout=timeout)
     )
+    # _IS_SYNC is True in the generated synchronous flavor, where a regular
+    # function is the correct thing to pass and nothing is awaited.
+    if not _IS_SYNC and not inspect.isawaitable(result):
+        _close_rejected_kms_socket(result)
+        # "async" and "def" are deliberately split across the next two source
+        # lines: tools/synchro.py deletes "async " from any line that spells
+        # those two words together, which would garble this message in the
+        # generated synchronous file even though the branch never runs there.
+        raise _KMSCallbackContractError(
+            "kms_connect_callback must be a coroutine function (an 'async"
+            " def') for the async driver, but calling it returned "
+            f"{type(result)}, which is not awaitable."
+        )
+    sock = await result
     if not isinstance(sock, socket.socket) or isinstance(sock, ssl.SSLSocket):
+        _close_rejected_kms_socket(sock)
         raise _KMSCallbackContractError(
             "kms_connect_callback must return a connected, unwrapped "
             f"socket.socket, not {type(sock)}. TLS cannot be layered over an "

--- a/pymongo/asynchronous/encryption.py
+++ b/pymongo/asynchronous/encryption.py
@@ -142,32 +142,26 @@ async def _connect_kms(
         except Exception as exc:
             _raise_connection_failure(address, exc, timeout_details=_get_timeout_details(opts))
 
-    # Let the caller open the connection, then apply TLS ourselves so that SNI
-    # and certificate verification still target the KMS host even when the
-    # socket actually terminates at a proxy.
+    # TLS is applied here, against address, so verification targets the KMS
+    # host even when the socket terminates at a proxy.
     result = kms_connect_callback(
         KMSConnectContext(host=address[0], port=cast(int, address[1]), timeout=timeout)
     )
-    # _IS_SYNC is True in the generated synchronous module, where a regular
-    # function is the correct thing to pass and nothing is awaited.
+    # The synchronous module takes a regular function and awaits nothing.
     if not _IS_SYNC and not inspect.isawaitable(result):
         _close_rejected_kms_socket(result)
         raise ConfigurationError(
             "kms_connect_callback must be a coroutine function for the async "
-            f"API, but calling it returned {type(result)}, which is not awaitable."
+            f"API, but returned {type(result)}."
         )
     sock = await result
     if not isinstance(sock, socket.socket) or isinstance(sock, ssl.SSLSocket):
         _close_rejected_kms_socket(sock)
         raise ConfigurationError(
             "kms_connect_callback must return a connected, unwrapped "
-            f"socket.socket, not {type(sock)}. Streams, transports and "
-            "transport sockets cannot be used; try loop.sock_connect. For a "
-            "TLS proxy, relay through a socket.socketpair and return the plain end."
+            f"socket.socket, not {type(sock)}; consider HTTPProxyKMSConnect."
         )
-    # ssl.SSLContext.wrap_socket refuses a non-blocking socket, and a callback
-    # has no reason to care which mode it left the socket in, so normalize it
-    # here rather than pushing the requirement onto the caller.
+    # wrap_socket refuses a non-blocking socket, so normalize the mode here.
     sock.settimeout(opts.socket_timeout)
     try:
         return await _async_wrap_socket_tls(sock, address, opts)

--- a/pymongo/asynchronous/encryption.py
+++ b/pymongo/asynchronous/encryption.py
@@ -713,9 +713,8 @@ class AsyncClientEncryption(Generic[_DocumentType]):
             KMS host, used to route KMS requests through an HTTP proxy. It
             receives a :class:`~pymongo.encryption_options.KMSConnectContext`
             and returns a connected, unwrapped :class:`socket.socket`; the
-            driver then performs the KMS TLS handshake over it. Must be a
-            coroutine function. See
-            :class:`~pymongo.encryption_options.KMSConnectContext` for a worked
+            driver then performs the KMS TLS handshake over it. Must be a coroutine function.
+            See :class:`~pymongo.encryption_options.KMSConnectContext` for a worked
             HTTP ``CONNECT`` example. Defaults to ``None``, meaning the driver
             connects to KMS hosts directly.
 

--- a/pymongo/asynchronous/encryption.py
+++ b/pymongo/asynchronous/encryption.py
@@ -727,10 +727,11 @@ class AsyncClientEncryption(Generic[_DocumentType]):
             KMS host, used to route KMS requests through an HTTP proxy. It
             receives a :class:`~pymongo.encryption_options.KMSConnectContext`
             and returns a connected, unwrapped :class:`socket.socket`; the
-            driver then performs the KMS TLS handshake over it.
-            See :class:`~pymongo.encryption_options.KMSConnectContext` for a worked
-            HTTP ``CONNECT`` example. Defaults to ``None``, meaning the driver
-            connects to KMS hosts directly.
+            driver then performs the KMS TLS handshake over it. For an ordinary
+            HTTP proxy, pass
+            :class:`~pymongo.encryption_options.AsyncHTTPProxyKMSConnect`.
+            Defaults to ``None``, meaning the driver connects to KMS hosts
+            directly.
 
         .. versionchanged:: 4.18
            Added the `kms_connect_callback` parameter.

--- a/pymongo/asynchronous/encryption.py
+++ b/pymongo/asynchronous/encryption.py
@@ -161,9 +161,12 @@ async def _connect_kms(
         _close_rejected_kms_socket(sock)
         raise ConfigurationError(
             "kms_connect_callback must return a connected, unwrapped "
-            f"socket.socket, not {type(sock)}. TLS cannot be layered over an "
-            "already-wrapped socket; to reach the proxy over TLS, relay through "
-            "a socket.socketpair and return the plain end."
+            f"socket.socket, not {type(sock)}. An asyncio stream or transport, "
+            "including the object from transport.get_extra_info('socket'), "
+            "cannot be used; connect with loop.sock_connect instead. TLS cannot "
+            "be layered over an already-wrapped socket either; to reach the "
+            "proxy over TLS, relay through a socket.socketpair and return the "
+            "plain end."
         )
     # ssl.SSLContext.wrap_socket refuses a non-blocking socket, and a callback
     # has no reason to care which mode it left the socket in, so normalize it

--- a/pymongo/encryption_options.py
+++ b/pymongo/encryption_options.py
@@ -157,8 +157,9 @@ class KMSConnectContext:
     :param host: Hostname of the KMS server, and the target of TLS certificate
         and hostname verification.
     :param port: Port of the KMS server.
-    :param timeout: Seconds remaining before the operation's timeout expires,
-        or ``None`` when no timeout applies.
+    :param timeout: Seconds remaining in the operation's timeout budget when
+        one is active, otherwise the driver's default KMS connect timeout.
+        Always a positive number; the driver never passes ``None``.
 
     .. versionadded:: 4.18
     """

--- a/pymongo/encryption_options.py
+++ b/pymongo/encryption_options.py
@@ -20,6 +20,7 @@
 from __future__ import annotations
 
 import asyncio
+import functools
 import socket
 import ssl
 import threading
@@ -84,8 +85,8 @@ class KMSConnectContext:
     proxy authentication.
 
     The asynchronous API requires a coroutine function. Run any blocking
-    connect in a thread with :func:`asyncio.to_thread` so the event loop stays
-    free.
+    connect in a thread, with :meth:`asyncio.loop.run_in_executor` or
+    :func:`asyncio.to_thread`, so the event loop stays free.
 
     :param host: Hostname of the KMS server, and the target of TLS certificate
         and hostname verification.
@@ -220,7 +221,10 @@ class AsyncHTTPProxyKMSConnect(HTTPProxyKMSConnect):
     """
 
     async def __call__(self, context: KMSConnectContext) -> socket.socket:  # type: ignore[override]
-        return await asyncio.to_thread(super().__call__, context)
+        # run_in_executor rather than asyncio.to_thread, matching how
+        # auth_oidc.py runs a user-supplied callback off the event loop.
+        connect = functools.partial(super().__call__, context)
+        return await asyncio.get_running_loop().run_in_executor(None, connect)
 
 
 class AutoEncryptionOpts:

--- a/pymongo/encryption_options.py
+++ b/pymongo/encryption_options.py
@@ -64,42 +64,23 @@ def check_min_pymongocrypt() -> None:
 class KMSConnectContext:
     """Information about a pending KMS connection.
 
-    An instance is passed to the ``kms_connect_callback`` configured on
-    :class:`AutoEncryptionOpts`, :class:`~pymongo.encryption.ClientEncryption`,
-    or :class:`~pymongo.asynchronous.encryption.AsyncClientEncryption`.
+    Passed to ``kms_connect_callback``, which must return a plain, unwrapped
+    :class:`socket.socket`. The driver performs the KMS TLS handshake over it
+    against ``host``, not the peer actually reached, which is what makes
+    proxying safe.
 
-    The callback connects to ``host``:``port`` and returns a plain, unwrapped
-    :class:`socket.socket`. The driver performs the KMS TLS handshake over it,
-    verifying against ``host`` rather than the peer actually reached, which is
-    what makes proxying safe. The driver also sets the socket's timeout, so the
-    mode the callback leaves it in does not matter.
+    Prefer :class:`HTTPProxyKMSConnect` or :class:`AsyncHTTPProxyKMSConnect`
+    over writing a callback.
 
-    Streams and transports do not work: :func:`asyncio.open_connection` and
-    :meth:`asyncio.loop.create_connection` do not return sockets, and
-    ``transport.get_extra_info("socket")`` returns one the loop still owns.
-    :meth:`asyncio.loop.sock_connect` is fine.
-
-    For an ordinary HTTP proxy, use :class:`HTTPProxyKMSConnect` or
-    :class:`AsyncHTTPProxyKMSConnect` rather than writing this yourself. Supply
-    a callback directly only when you need something they do not cover, such as
-    proxy authentication.
-
-    The asynchronous API requires a coroutine function. Run any blocking
-    connect in a thread, with :meth:`asyncio.loop.run_in_executor` or
-    :func:`asyncio.to_thread`, so the event loop stays free.
-
-    :param host: Hostname of the KMS server, and the target of TLS certificate
-        and hostname verification.
+    :param host: Hostname of the KMS server, and the TLS verification target.
     :param port: Port of the KMS server.
-    :param timeout: Seconds remaining in the operation's timeout budget when
-        one is active, otherwise the driver's default KMS connect timeout.
-        Always a positive number; the driver never passes ``None``.
+    :param timeout: Seconds left in the timeout budget, else the default KMS
+        connect timeout. Never ``None``.
 
-    .. note:: ``timeoutMS`` on a :class:`~pymongo.encryption.ClientEncryption`
-       or its key vault client does not constrain KMS requests, so ``timeout``
-       is always the default for explicit encryption. Automatic encryption
-       passes the remaining budget. This is a known deviation from the Client
-       Side Operations Timeout specification, tracked in PYTHON-6037.
+    .. note:: ``timeoutMS`` does not constrain KMS requests for explicit
+       encryption, so ``timeout`` is always the default there. Automatic
+       encryption passes the remaining budget. This deviates from the Client
+       Side Operations Timeout specification; see PYTHON-6037.
 
     .. versionadded:: 4.18
     """
@@ -129,9 +110,8 @@ class HTTPProxyKMSConnect:
           kms_connect_callback=HTTPProxyKMSConnect("proxy.example.com", 8080),
       )
 
-    To reach the proxy itself over TLS, pass an :class:`ssl.SSLContext`. It is
-    used only for the connection to the proxy; the driver still negotiates KMS
-    TLS end to end through the tunnel::
+    To reach the proxy over TLS, pass an :class:`ssl.SSLContext`. It applies
+    only to the proxy connection; KMS TLS is still negotiated end to end::
 
       import ssl
 
@@ -169,16 +149,10 @@ class HTTPProxyKMSConnect:
     def _bridge(self, proxy: socket.socket) -> socket.socket:
         """Relay a TLS proxy connection through a socketpair.
 
-        The driver wraps what we return in KMS TLS, and Python cannot layer TLS
-        over an :class:`ssl.SSLSocket`, so hand back the plain end of a pair and
-        pump bytes between it and the proxy connection.
-
-        Threads rather than asyncio tasks in :class:`AsyncHTTPProxyKMSConnect`:
-        ``proxy`` may be an :class:`ssl.SSLSocket`, which the event loop refuses
-        to read, so tasks would mean reimplementing the connect and CONNECT
-        handshake on streams.
-        A KMS connection happens once per data key and is then cached, so the
-        threads are short-lived and rare.
+        Python cannot layer TLS over an :class:`ssl.SSLSocket`, so return the
+        plain end of a pair. Threads rather than tasks, even in
+        :class:`AsyncHTTPProxyKMSConnect`, because the event loop cannot read
+        an :class:`ssl.SSLSocket`.
         """
         driver_side, relay_side = socket.socketpair()
 
@@ -228,8 +202,7 @@ class AsyncHTTPProxyKMSConnect(HTTPProxyKMSConnect):
     """
 
     async def __call__(self, context: KMSConnectContext) -> socket.socket:  # type: ignore[override]
-        # run_in_executor rather than asyncio.to_thread, matching how
-        # auth_oidc.py runs a user-supplied callback off the event loop.
+        # run_in_executor, as auth_oidc.py does for user callbacks.
         connect = functools.partial(super().__call__, context)
         return await asyncio.get_running_loop().run_in_executor(None, connect)
 

--- a/pymongo/encryption_options.py
+++ b/pymongo/encryption_options.py
@@ -64,21 +64,21 @@ class KMSConnectContext:
     :class:`AutoEncryptionOpts`, :class:`~pymongo.encryption.ClientEncryption`,
     or :class:`~pymongo.asynchronous.encryption.AsyncClientEncryption`.
 
-    The callback opens a connection to ``host``:``port`` and returns it. The
-    driver then performs the KMS TLS handshake over that socket, so the
-    callback must return a plain, unwrapped :class:`socket.socket`. Certificate
-    and hostname verification target ``host``, not whatever peer the socket is
-    actually connected to, which is what makes proxying safe.
+    The callback connects to ``host``:``port`` and returns a plain, unwrapped
+    :class:`socket.socket`. The driver then performs the KMS TLS handshake over
+    it, verifying the certificate and hostname against ``host`` rather than the
+    peer the socket actually reached. That is what makes proxying safe.
 
-    To reach a KMS host through an HTTP proxy, connect to the proxy and issue
-    an HTTP ``CONNECT`` request::
+    The socket must be in blocking or timeout mode.
+    :meth:`ssl.SSLContext.wrap_socket` rejects non-blocking sockets, which rules
+    out :func:`asyncio.open_connection` and
+    :meth:`asyncio.loop.create_connection`.
+
+    To reach a KMS host through an HTTP proxy, tunnel with ``CONNECT``::
 
       import socket
 
-      def connect_through_proxy(context):
-          sock = socket.create_connection(
-              ("proxy.example.com", 8080), timeout=context.timeout
-          )
+      def open_tunnel(sock, context):
           target = f"{context.host}:{context.port}"
           sock.sendall(
               f"CONNECT {target} HTTP/1.1\\r\\nHost: {target}\\r\\n\\r\\n".encode()
@@ -87,12 +87,20 @@ class KMSConnectContext:
           while b"\\r\\n\\r\\n" not in response:
               chunk = sock.recv(4096)
               if not chunk:
-                  sock.close()
                   raise OSError("proxy closed the connection")
               response += chunk
           if not response.startswith(b"HTTP/1.1 200"):
+              raise OSError(f"CONNECT failed: {response.splitlines()[0]!r}")
+
+      def connect_through_proxy(context):
+          sock = socket.create_connection(
+              ("proxy.example.com", 8080), timeout=context.timeout
+          )
+          try:
+              open_tunnel(sock, context)
+          except OSError:
               sock.close()
-              raise OSError(f"proxy CONNECT failed: {response.splitlines()[0]!r}")
+              raise
           return sock
 
       opts = AutoEncryptionOpts(
@@ -101,54 +109,29 @@ class KMSConnectContext:
           kms_connect_callback=connect_through_proxy,
       )
 
-    The socket must be in blocking or timeout mode.
-    :meth:`ssl.SSLContext.wrap_socket` rejects a non-blocking socket, which
-    rules out the transports returned by :func:`asyncio.open_connection` and
-    :meth:`asyncio.loop.create_connection`.
-
-    For :class:`~pymongo.asynchronous.encryption.AsyncClientEncryption` and
-    :class:`~pymongo.asynchronous.mongo_client.AsyncMongoClient`, the callback
-    must be a coroutine function. Keep the event loop free by running the
-    blocking connect in a thread::
-
-      import asyncio
+    The async API requires a coroutine function. Run the blocking connect in a
+    thread to keep the event loop free::
 
       async def async_connect_through_proxy(context):
           return await asyncio.to_thread(connect_through_proxy, context)
 
-      opts = AutoEncryptionOpts(
-          kms_providers={"aws": aws_creds},
-          key_vault_namespace="keyvault.datakeys",
-          kms_connect_callback=async_connect_through_proxy,
-      )
+    Reaching the proxy itself over TLS needs one extra step, because Python
+    cannot layer TLS over an :class:`ssl.SSLSocket`. Relay the proxy connection
+    through a :func:`socket.socketpair` and return the plain end::
 
-    Reaching the proxy itself over TLS takes one extra step. Python cannot
-    layer a second TLS session over an :class:`ssl.SSLSocket`, so the callback
-    cannot return its TLS connection to the proxy directly. Bridge it to a
-    :func:`socket.socketpair` and return the plain end instead::
-
-      import socket, ssl, threading
+      import ssl, threading
 
       def connect_through_tls_proxy(context):
-          proxy_ctx = ssl.create_default_context(cafile="proxy-ca.pem")
+          ctx = ssl.create_default_context(cafile="proxy-ca.pem")
           raw = socket.create_connection(
               ("proxy.example.com", 8443), timeout=context.timeout
           )
-          proxy = proxy_ctx.wrap_socket(raw, server_hostname="proxy.example.com")
-          target = f"{context.host}:{context.port}"
-          proxy.sendall(
-              f"CONNECT {target} HTTP/1.1\\r\\nHost: {target}\\r\\n\\r\\n".encode()
-          )
-          response = b""
-          while b"\\r\\n\\r\\n" not in response:
-              chunk = proxy.recv(4096)
-              if not chunk:
-                  proxy.close()
-                  raise OSError("proxy closed the connection")
-              response += chunk
-          if not response.startswith(b"HTTP/1.1 200"):
+          proxy = ctx.wrap_socket(raw, server_hostname="proxy.example.com")
+          try:
+              open_tunnel(proxy, context)
+          except OSError:
               proxy.close()
-              raise OSError(f"proxy CONNECT failed: {response.splitlines()[0]!r}")
+              raise
 
           driver_side, relay_side = socket.socketpair()
 
@@ -162,16 +145,15 @@ class KMSConnectContext:
               except OSError:
                   pass
               finally:
-                  # Unblock the sibling thread with EOF instead of closing a
-                  # socket it may be reading, then close only this side.
+                  # EOF the peer instead of closing a socket it may be reading.
                   try:
                       dst.shutdown(socket.SHUT_RDWR)
                   except OSError:
                       pass
                   src.close()
 
-          threading.Thread(target=relay, args=(relay_side, proxy), daemon=True).start()
-          threading.Thread(target=relay, args=(proxy, relay_side), daemon=True).start()
+          for pair in ((relay_side, proxy), (proxy, relay_side)):
+              threading.Thread(target=relay, args=pair, daemon=True).start()
           return driver_side
 
     :param host: Hostname of the KMS server, and the target of TLS certificate
@@ -181,13 +163,12 @@ class KMSConnectContext:
         one is active, otherwise the driver's default KMS connect timeout.
         Always a positive number; the driver never passes ``None``.
 
-    .. note:: ``timeoutMS`` configured on a
-       :class:`~pymongo.encryption.ClientEncryption` or on its key vault client
-       does not currently constrain KMS requests, so for explicit encryption
-       ``timeout`` is always the default KMS connect timeout. Automatic
-       encryption is unaffected and passes the remaining budget. This is a
-       known deviation from the Client Side Operations Timeout specification,
-       tracked in PYTHON-6037.
+    .. note:: ``timeoutMS`` on a
+       :class:`~pymongo.encryption.ClientEncryption` or its key vault client
+       does not constrain KMS requests, so for explicit encryption ``timeout``
+       is always the default. Automatic encryption passes the remaining budget.
+       This deviates from the Client Side Operations Timeout specification and
+       is tracked in PYTHON-6037.
 
     .. versionadded:: 4.18
     """

--- a/pymongo/encryption_options.py
+++ b/pymongo/encryption_options.py
@@ -19,8 +19,10 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, Optional, TypedDict
+import socket
+from collections.abc import Awaitable, Mapping
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Callable, Optional, TypedDict
 
 from pymongo.uri_parser_shared import _parse_kms_tls_options
 
@@ -54,6 +56,124 @@ def check_min_pymongocrypt() -> None:
         )
 
 
+@dataclass(frozen=True)
+class KMSConnectContext:
+    """Information about a pending KMS connection.
+
+    An instance is passed to the ``kms_connect_callback`` configured on
+    :class:`AutoEncryptionOpts`, :class:`~pymongo.encryption.ClientEncryption`,
+    or :class:`~pymongo.asynchronous.encryption.AsyncClientEncryption`.
+
+    The callback opens a connection to ``host``:``port`` and returns it. The
+    driver then performs the KMS TLS handshake over that socket, so the
+    callback must return a plain, unwrapped :class:`socket.socket`. Certificate
+    and hostname verification target ``host``, not whatever peer the socket is
+    actually connected to, which is what makes proxying safe.
+
+    To reach a KMS host through an HTTP proxy, connect to the proxy and issue
+    an HTTP ``CONNECT`` request::
+
+      import socket
+
+      def connect_through_proxy(context):
+          sock = socket.create_connection(
+              ("proxy.example.com", 8080), timeout=context.timeout
+          )
+          target = f"{context.host}:{context.port}"
+          sock.sendall(
+              f"CONNECT {target} HTTP/1.1\\r\\nHost: {target}\\r\\n\\r\\n".encode()
+          )
+          response = b""
+          while b"\\r\\n\\r\\n" not in response:
+              chunk = sock.recv(4096)
+              if not chunk:
+                  sock.close()
+                  raise OSError("proxy closed the connection")
+              response += chunk
+          if not response.startswith(b"HTTP/1.1 200"):
+              sock.close()
+              raise OSError(f"proxy CONNECT failed: {response.splitlines()[0]!r}")
+          return sock
+
+      opts = AutoEncryptionOpts(
+          kms_providers={"aws": aws_creds},
+          key_vault_namespace="keyvault.datakeys",
+          kms_connect_callback=connect_through_proxy,
+      )
+
+    For :class:`~pymongo.asynchronous.encryption.AsyncClientEncryption` and
+    :class:`~pymongo.asynchronous.mongo_client.AsyncMongoClient`, the callback
+    must be a coroutine function. It must not block the event loop, so drive
+    the connection with :mod:`asyncio` or hand the blocking work to a thread
+    with :func:`asyncio.to_thread`.
+
+    Reaching the proxy itself over TLS takes one extra step. Python cannot
+    layer a second TLS session over an :class:`ssl.SSLSocket`, so the callback
+    cannot return its TLS connection to the proxy directly. Bridge it to a
+    :func:`socket.socketpair` and return the plain end instead::
+
+      import socket, ssl, threading
+
+      def connect_through_tls_proxy(context):
+          proxy_ctx = ssl.create_default_context(cafile="proxy-ca.pem")
+          raw = socket.create_connection(
+              ("proxy.example.com", 8443), timeout=context.timeout
+          )
+          proxy = proxy_ctx.wrap_socket(raw, server_hostname="proxy.example.com")
+          target = f"{context.host}:{context.port}"
+          proxy.sendall(
+              f"CONNECT {target} HTTP/1.1\\r\\nHost: {target}\\r\\n\\r\\n".encode()
+          )
+          response = b""
+          while b"\\r\\n\\r\\n" not in response:
+              chunk = proxy.recv(4096)
+              if not chunk:
+                  proxy.close()
+                  raise OSError("proxy closed the connection")
+              response += chunk
+          if not response.startswith(b"HTTP/1.1 200"):
+              proxy.close()
+              raise OSError(f"proxy CONNECT failed: {response.splitlines()[0]!r}")
+
+          driver_side, relay_side = socket.socketpair()
+
+          def relay(src, dst):
+              try:
+                  while True:
+                      buf = src.recv(16384)
+                      if not buf:
+                          break
+                      dst.sendall(buf)
+              except OSError:
+                  pass
+              finally:
+                  src.close()
+                  dst.close()
+
+          threading.Thread(target=relay, args=(relay_side, proxy), daemon=True).start()
+          threading.Thread(target=relay, args=(proxy, relay_side), daemon=True).start()
+          return driver_side
+
+    :param host: Hostname of the KMS server, and the target of TLS certificate
+        and hostname verification.
+    :param port: Port of the KMS server.
+    :param timeout: Seconds remaining before the operation's timeout expires,
+        or ``None`` when no timeout applies.
+
+    .. versionadded:: 4.18
+    """
+
+    host: str
+    port: int
+    timeout: Optional[float]
+
+
+# A callback that opens a connection to a KMS host. The async driver requires a
+# coroutine function; the synchronous driver requires a regular function.
+AsyncKMSConnectCallback = Callable[[KMSConnectContext], Awaitable[socket.socket]]
+KMSConnectCallback = Callable[[KMSConnectContext], socket.socket]
+
+
 class AutoEncryptionOpts:
     """Options to configure automatic client-side field level encryption."""
 
@@ -74,6 +194,7 @@ class AutoEncryptionOpts:
         bypass_query_analysis: bool = False,
         encrypted_fields_map: Optional[Mapping[str, Any]] = None,
         key_expiration_ms: Optional[int] = None,
+        kms_connect_callback: Optional[Callable[[KMSConnectContext], Any]] = None,
     ) -> None:
         """Options to configure automatic client-side field level encryption.
 
@@ -211,7 +332,20 @@ class AutoEncryptionOpts:
         :param key_expiration_ms: The cache expiration time for data encryption keys.
             Defaults to ``None`` which defers to libmongocrypt's default which is currently 60000.
             Set to 0 to disable key expiration.
+        :param kms_connect_callback: A callable that opens the connection to a
+            KMS host, used to route KMS requests through an HTTP proxy. It
+            receives a :class:`KMSConnectContext` and returns a connected,
+            unwrapped :class:`socket.socket`; the driver then performs the KMS
+            TLS handshake over it. Must be a coroutine function for
+            :class:`~pymongo.asynchronous.mongo_client.AsyncMongoClient` and a
+            regular function for
+            :class:`~pymongo.synchronous.mongo_client.MongoClient`. See
+            :class:`KMSConnectContext` for a worked HTTP ``CONNECT`` example.
+            Defaults to ``None``, meaning the driver connects to KMS hosts
+            directly.
 
+        .. versionchanged:: 4.18
+           Added the `kms_connect_callback` parameter.
         .. versionchanged:: 4.12
            Added the `key_expiration_ms` parameter.
         .. versionchanged:: 4.2
@@ -258,6 +392,11 @@ class AutoEncryptionOpts:
         self._async_kms_ssl_contexts: Optional[dict[str, SSLContext]] = None
         self._bypass_query_analysis = bypass_query_analysis
         self._key_expiration_ms = key_expiration_ms
+        if kms_connect_callback is not None and not callable(kms_connect_callback):
+            raise TypeError(
+                f"kms_connect_callback must be callable, not {type(kms_connect_callback)}"
+            )
+        self._kms_connect_callback = kms_connect_callback
 
     def _kms_ssl_contexts(self, is_sync: bool) -> dict[str, SSLContext]:
         if is_sync:

--- a/pymongo/encryption_options.py
+++ b/pymongo/encryption_options.py
@@ -172,6 +172,12 @@ class HTTPProxyKMSConnect:
         The driver wraps what we return in KMS TLS, and Python cannot layer TLS
         over an :class:`ssl.SSLSocket`, so hand back the plain end of a pair and
         pump bytes between it and the proxy connection.
+
+        Threads rather than asyncio tasks: ``proxy`` may be an
+        :class:`ssl.SSLSocket`, which the event loop refuses to read, so tasks
+        would mean reimplementing the connect and CONNECT handshake on streams.
+        A KMS connection happens once per data key and is then cached, so the
+        threads are short-lived and rare.
         """
         driver_side, relay_side = socket.socketpair()
 

--- a/pymongo/encryption_options.py
+++ b/pymongo/encryption_options.py
@@ -90,8 +90,7 @@ class KMSConnectContext:
     timeout: Optional[float]
 
 
-# A callback that opens a connection to a KMS host. The async driver requires a
-# coroutine function; the synchronous driver requires a regular function.
+# A callback that opens a connection to a KMS host.
 AsyncKMSConnectCallback = Callable[[KMSConnectContext], Awaitable[socket.socket]]
 KMSConnectCallback = Callable[[KMSConnectContext], socket.socket]
 

--- a/pymongo/encryption_options.py
+++ b/pymongo/encryption_options.py
@@ -98,8 +98,8 @@ class KMSConnectContext:
     .. note:: ``timeoutMS`` on a :class:`~pymongo.encryption.ClientEncryption`
        or its key vault client does not constrain KMS requests, so ``timeout``
        is always the default for explicit encryption. Automatic encryption
-       passes the remaining budget. A known deviation from the Client Side
-       Operations Timeout specification, tracked in PYTHON-6037.
+       passes the remaining budget. This is a known deviation from the Client
+       Side Operations Timeout specification, tracked in PYTHON-6037.
 
     .. versionadded:: 4.18
     """

--- a/pymongo/encryption_options.py
+++ b/pymongo/encryption_options.py
@@ -101,11 +101,26 @@ class KMSConnectContext:
           kms_connect_callback=connect_through_proxy,
       )
 
+    The socket must be in blocking or timeout mode.
+    :meth:`ssl.SSLContext.wrap_socket` rejects a non-blocking socket, which
+    rules out the transports returned by :func:`asyncio.open_connection` and
+    :meth:`asyncio.loop.create_connection`.
+
     For :class:`~pymongo.asynchronous.encryption.AsyncClientEncryption` and
     :class:`~pymongo.asynchronous.mongo_client.AsyncMongoClient`, the callback
-    must be a coroutine function. It must not block the event loop, so drive
-    the connection with :mod:`asyncio` or hand the blocking work to a thread
-    with :func:`asyncio.to_thread`.
+    must be a coroutine function. Keep the event loop free by running the
+    blocking connect in a thread::
+
+      import asyncio
+
+      async def async_connect_through_proxy(context):
+          return await asyncio.to_thread(connect_through_proxy, context)
+
+      opts = AutoEncryptionOpts(
+          kms_providers={"aws": aws_creds},
+          key_vault_namespace="keyvault.datakeys",
+          kms_connect_callback=async_connect_through_proxy,
+      )
 
     Reaching the proxy itself over TLS takes one extra step. Python cannot
     layer a second TLS session over an :class:`ssl.SSLSocket`, so the callback
@@ -147,8 +162,13 @@ class KMSConnectContext:
               except OSError:
                   pass
               finally:
+                  # Unblock the sibling thread with EOF instead of closing a
+                  # socket it may be reading, then close only this side.
+                  try:
+                      dst.shutdown(socket.SHUT_RDWR)
+                  except OSError:
+                      pass
                   src.close()
-                  dst.close()
 
           threading.Thread(target=relay, args=(relay_side, proxy), daemon=True).start()
           threading.Thread(target=relay, args=(proxy, relay_side), daemon=True).start()

--- a/pymongo/encryption_options.py
+++ b/pymongo/encryption_options.py
@@ -19,7 +19,10 @@
 
 from __future__ import annotations
 
+import asyncio
 import socket
+import ssl
+import threading
 from collections.abc import Awaitable, Mapping
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Callable, Optional, TypedDict
@@ -75,87 +78,14 @@ class KMSConnectContext:
     ``transport.get_extra_info("socket")`` returns one the loop still owns.
     :meth:`asyncio.loop.sock_connect` is fine.
 
-    To reach a KMS host through an HTTP proxy, tunnel with ``CONNECT``::
+    For an ordinary HTTP proxy, use :class:`HTTPProxyKMSConnect` or
+    :class:`AsyncHTTPProxyKMSConnect` rather than writing this yourself. Supply
+    a callback directly only when you need something they do not cover, such as
+    proxy authentication.
 
-      import socket
-
-      def open_tunnel(sock, context):
-          target = f"{context.host}:{context.port}"
-          sock.sendall(
-              f"CONNECT {target} HTTP/1.1\\r\\nHost: {target}\\r\\n\\r\\n".encode()
-          )
-          response = b""
-          while b"\\r\\n\\r\\n" not in response:
-              chunk = sock.recv(4096)
-              if not chunk:
-                  raise OSError("proxy closed the connection")
-              response += chunk
-          if not response.startswith(b"HTTP/1.1 200"):
-              raise OSError(f"CONNECT failed: {response.splitlines()[0]!r}")
-
-      def connect_through_proxy(context):
-          sock = socket.create_connection(
-              ("proxy.example.com", 8080), timeout=context.timeout
-          )
-          try:
-              open_tunnel(sock, context)
-          except OSError:
-              sock.close()
-              raise
-          return sock
-
-      opts = AutoEncryptionOpts(
-          kms_providers={"aws": aws_creds},
-          key_vault_namespace="keyvault.datakeys",
-          kms_connect_callback=connect_through_proxy,
-      )
-
-    The async API requires a coroutine function. Run the blocking connect in a
-    thread to keep the event loop free::
-
-      async def async_connect_through_proxy(context):
-          return await asyncio.to_thread(connect_through_proxy, context)
-
-    Reaching the proxy over TLS needs one extra step, because Python cannot
-    layer TLS over an :class:`ssl.SSLSocket`. Relay through a
-    :func:`socket.socketpair` and return the plain end::
-
-      import ssl, threading
-
-      def connect_through_tls_proxy(context):
-          ctx = ssl.create_default_context(cafile="proxy-ca.pem")
-          raw = socket.create_connection(
-              ("proxy.example.com", 8443), timeout=context.timeout
-          )
-          proxy = ctx.wrap_socket(raw, server_hostname="proxy.example.com")
-          try:
-              open_tunnel(proxy, context)
-          except OSError:
-              proxy.close()
-              raise
-
-          driver_side, relay_side = socket.socketpair()
-
-          def relay(src, dst):
-              try:
-                  while True:
-                      buf = src.recv(16384)
-                      if not buf:
-                          break
-                      dst.sendall(buf)
-              except OSError:
-                  pass
-              finally:
-                  # EOF the peer instead of closing a socket it may be reading.
-                  try:
-                      dst.shutdown(socket.SHUT_RDWR)
-                  except OSError:
-                      pass
-                  src.close()
-
-          for pair in ((relay_side, proxy), (proxy, relay_side)):
-              threading.Thread(target=relay, args=pair, daemon=True).start()
-          return driver_side
+    The asynchronous API requires a coroutine function. Run any blocking
+    connect in a thread with :func:`asyncio.to_thread` so the event loop stays
+    free.
 
     :param host: Hostname of the KMS server, and the target of TLS certificate
         and hostname verification.
@@ -182,6 +112,115 @@ class KMSConnectContext:
 # coroutine function; the synchronous driver requires a regular function.
 AsyncKMSConnectCallback = Callable[[KMSConnectContext], Awaitable[socket.socket]]
 KMSConnectCallback = Callable[[KMSConnectContext], socket.socket]
+
+
+class HTTPProxyKMSConnect:
+    """Route KMS connections through an HTTP proxy, for the synchronous API.
+
+    Pass an instance as ``kms_connect_callback`` to reach KMS hosts through a
+    forward proxy that speaks HTTP ``CONNECT``::
+
+      from pymongo.encryption_options import HTTPProxyKMSConnect
+
+      opts = AutoEncryptionOpts(
+          kms_providers={"aws": aws_creds},
+          key_vault_namespace="keyvault.datakeys",
+          kms_connect_callback=HTTPProxyKMSConnect("proxy.example.com", 8080),
+      )
+
+    To reach the proxy itself over TLS, pass an :class:`ssl.SSLContext`. It is
+    used only for the connection to the proxy; the driver still negotiates KMS
+    TLS end to end through the tunnel::
+
+      import ssl
+
+      proxy_tls = ssl.create_default_context(cafile="proxy-ca.pem")
+      callback = HTTPProxyKMSConnect("proxy.example.com", 8443, proxy_tls)
+
+    Use :class:`AsyncHTTPProxyKMSConnect` with the asynchronous API.
+
+    :param host: Hostname of the proxy.
+    :param port: Port of the proxy.
+    :param ssl_context: Optional :class:`ssl.SSLContext` for connecting to the
+        proxy over TLS. Defaults to ``None``, meaning a plain connection.
+
+    .. versionadded:: 4.18
+    """
+
+    def __init__(self, host: str, port: int, ssl_context: Optional[ssl.SSLContext] = None):
+        self.host = host
+        self.port = port
+        self.ssl_context = ssl_context
+
+    def _tunnel(self, sock: socket.socket, context: KMSConnectContext) -> None:
+        target = f"{context.host}:{context.port}"
+        sock.sendall(f"CONNECT {target} HTTP/1.1\r\nHost: {target}\r\n\r\n".encode())
+        response = b""
+        while b"\r\n\r\n" not in response:
+            chunk = sock.recv(4096)
+            if not chunk:
+                raise OSError(f"proxy closed the connection while tunneling to {target}")
+            response += chunk
+        status = response.split(b"\r\n", 1)[0]
+        if not status.startswith(b"HTTP/1.1 200"):
+            raise OSError(f"proxy refused CONNECT to {target}: {status!r}")
+
+    def _bridge(self, proxy: socket.socket) -> socket.socket:
+        """Relay a TLS proxy connection through a socketpair.
+
+        The driver wraps what we return in KMS TLS, and Python cannot layer TLS
+        over an :class:`ssl.SSLSocket`, so hand back the plain end of a pair and
+        pump bytes between it and the proxy connection.
+        """
+        driver_side, relay_side = socket.socketpair()
+
+        def relay(src: socket.socket, dst: socket.socket) -> None:
+            try:
+                while True:
+                    buf = src.recv(16384)
+                    if not buf:
+                        break
+                    dst.sendall(buf)
+            except OSError:
+                pass
+            finally:
+                # EOF the peer instead of closing a socket it may be reading.
+                try:
+                    dst.shutdown(socket.SHUT_RDWR)
+                except OSError:
+                    pass
+                src.close()
+
+        for pair in ((relay_side, proxy), (proxy, relay_side)):
+            threading.Thread(target=relay, args=pair, daemon=True).start()
+        return driver_side
+
+    def __call__(self, context: KMSConnectContext) -> socket.socket:
+        sock = socket.create_connection((self.host, self.port), timeout=context.timeout)
+        try:
+            if self.ssl_context is not None:
+                sock = self.ssl_context.wrap_socket(sock, server_hostname=self.host)
+            self._tunnel(sock, context)
+        except BaseException:
+            sock.close()
+            raise
+        if self.ssl_context is None:
+            return sock
+        return self._bridge(sock)
+
+
+class AsyncHTTPProxyKMSConnect(HTTPProxyKMSConnect):
+    """Route KMS connections through an HTTP proxy, for the asynchronous API.
+
+    Behaves exactly like :class:`HTTPProxyKMSConnect`, but is a coroutine
+    callable and runs the blocking connect in a thread so the event loop stays
+    free.
+
+    .. versionadded:: 4.18
+    """
+
+    async def __call__(self, context: KMSConnectContext) -> socket.socket:  # type: ignore[override]
+        return await asyncio.to_thread(super().__call__, context)
 
 
 class AutoEncryptionOpts:

--- a/pymongo/encryption_options.py
+++ b/pymongo/encryption_options.py
@@ -65,18 +65,15 @@ class KMSConnectContext:
     or :class:`~pymongo.asynchronous.encryption.AsyncClientEncryption`.
 
     The callback connects to ``host``:``port`` and returns a plain, unwrapped
-    :class:`socket.socket`. The driver then performs the KMS TLS handshake over
-    it, verifying the certificate and hostname against ``host`` rather than the
-    peer the socket actually reached. That is what makes proxying safe.
+    :class:`socket.socket`. The driver performs the KMS TLS handshake over it,
+    verifying against ``host`` rather than the peer actually reached, which is
+    what makes proxying safe. The driver also sets the socket's timeout, so the
+    mode the callback leaves it in does not matter.
 
-    The callback must return a real socket that the event loop is not managing.
-    :func:`asyncio.open_connection` and :meth:`asyncio.loop.create_connection`
-    return a stream or transport rather than a socket, and the object from
-    ``transport.get_extra_info("socket")`` is a transport socket the loop still
-    owns, so none of them can be used here. :meth:`asyncio.loop.sock_connect`
-    is fine: it leaves an ordinary socket behind once it completes. The driver
-    sets the socket's timeout itself, so the mode the callback leaves it in
-    does not matter.
+    Streams and transports do not work: :func:`asyncio.open_connection` and
+    :meth:`asyncio.loop.create_connection` do not return sockets, and
+    ``transport.get_extra_info("socket")`` returns one the loop still owns.
+    :meth:`asyncio.loop.sock_connect` is fine.
 
     To reach a KMS host through an HTTP proxy, tunnel with ``CONNECT``::
 
@@ -119,9 +116,9 @@ class KMSConnectContext:
       async def async_connect_through_proxy(context):
           return await asyncio.to_thread(connect_through_proxy, context)
 
-    Reaching the proxy itself over TLS needs one extra step, because Python
-    cannot layer TLS over an :class:`ssl.SSLSocket`. Relay the proxy connection
-    through a :func:`socket.socketpair` and return the plain end::
+    Reaching the proxy over TLS needs one extra step, because Python cannot
+    layer TLS over an :class:`ssl.SSLSocket`. Relay through a
+    :func:`socket.socketpair` and return the plain end::
 
       import ssl, threading
 
@@ -167,12 +164,11 @@ class KMSConnectContext:
         one is active, otherwise the driver's default KMS connect timeout.
         Always a positive number; the driver never passes ``None``.
 
-    .. note:: ``timeoutMS`` on a
-       :class:`~pymongo.encryption.ClientEncryption` or its key vault client
-       does not constrain KMS requests, so for explicit encryption ``timeout``
-       is always the default. Automatic encryption passes the remaining budget.
-       This deviates from the Client Side Operations Timeout specification and
-       is tracked in PYTHON-6037.
+    .. note:: ``timeoutMS`` on a :class:`~pymongo.encryption.ClientEncryption`
+       or its key vault client does not constrain KMS requests, so ``timeout``
+       is always the default for explicit encryption. Automatic encryption
+       passes the remaining budget. A known deviation from the Client Side
+       Operations Timeout specification, tracked in PYTHON-6037.
 
     .. versionadded:: 4.18
     """

--- a/pymongo/encryption_options.py
+++ b/pymongo/encryption_options.py
@@ -71,10 +71,12 @@ class KMSConnectContext:
 
     The callback must return a real socket that the event loop is not managing.
     :func:`asyncio.open_connection` and :meth:`asyncio.loop.create_connection`
-    return a stream or transport rather than a socket, and the socket
-    underneath one stays registered with the running loop, so neither can be
-    used here. The driver sets the socket's timeout itself, so the mode the
-    callback leaves it in does not matter.
+    return a stream or transport rather than a socket, and the object from
+    ``transport.get_extra_info("socket")`` is a transport socket the loop still
+    owns, so none of them can be used here. :meth:`asyncio.loop.sock_connect`
+    is fine: it leaves an ordinary socket behind once it completes. The driver
+    sets the socket's timeout itself, so the mode the callback leaves it in
+    does not matter.
 
     To reach a KMS host through an HTTP proxy, tunnel with ``CONNECT``::
 

--- a/pymongo/encryption_options.py
+++ b/pymongo/encryption_options.py
@@ -181,6 +181,14 @@ class KMSConnectContext:
         one is active, otherwise the driver's default KMS connect timeout.
         Always a positive number; the driver never passes ``None``.
 
+    .. note:: ``timeoutMS`` configured on a
+       :class:`~pymongo.encryption.ClientEncryption` or on its key vault client
+       does not currently constrain KMS requests, so for explicit encryption
+       ``timeout`` is always the default KMS connect timeout. Automatic
+       encryption is unaffected and passes the remaining budget. This is a
+       known deviation from the Client Side Operations Timeout specification,
+       tracked in PYTHON-6037.
+
     .. versionadded:: 4.18
     """
 

--- a/pymongo/encryption_options.py
+++ b/pymongo/encryption_options.py
@@ -372,10 +372,10 @@ class AutoEncryptionOpts:
             TLS handshake over it. Must be a coroutine function for
             :class:`~pymongo.asynchronous.mongo_client.AsyncMongoClient` and a
             regular function for
-            :class:`~pymongo.synchronous.mongo_client.MongoClient`. See
-            :class:`KMSConnectContext` for a worked HTTP ``CONNECT`` example.
-            Defaults to ``None``, meaning the driver connects to KMS hosts
-            directly.
+            :class:`~pymongo.synchronous.mongo_client.MongoClient`. For an
+            ordinary HTTP proxy, pass :class:`HTTPProxyKMSConnect` or
+            :class:`AsyncHTTPProxyKMSConnect`. Defaults to ``None``, meaning
+            the driver connects to KMS hosts directly.
 
         .. versionchanged:: 4.18
            Added the `kms_connect_callback` parameter.

--- a/pymongo/encryption_options.py
+++ b/pymongo/encryption_options.py
@@ -69,10 +69,12 @@ class KMSConnectContext:
     it, verifying the certificate and hostname against ``host`` rather than the
     peer the socket actually reached. That is what makes proxying safe.
 
-    The socket must be in blocking or timeout mode.
-    :meth:`ssl.SSLContext.wrap_socket` rejects non-blocking sockets, which rules
-    out :func:`asyncio.open_connection` and
-    :meth:`asyncio.loop.create_connection`.
+    The callback must return a real socket that the event loop is not managing.
+    :func:`asyncio.open_connection` and :meth:`asyncio.loop.create_connection`
+    return a stream or transport rather than a socket, and the socket
+    underneath one stays registered with the running loop, so neither can be
+    used here. The driver sets the socket's timeout itself, so the mode the
+    callback leaves it in does not matter.
 
     To reach a KMS host through an HTTP proxy, tunnel with ``CONNECT``::
 

--- a/pymongo/encryption_options.py
+++ b/pymongo/encryption_options.py
@@ -173,9 +173,10 @@ class HTTPProxyKMSConnect:
         over an :class:`ssl.SSLSocket`, so hand back the plain end of a pair and
         pump bytes between it and the proxy connection.
 
-        Threads rather than asyncio tasks: ``proxy`` may be an
-        :class:`ssl.SSLSocket`, which the event loop refuses to read, so tasks
-        would mean reimplementing the connect and CONNECT handshake on streams.
+        Threads rather than asyncio tasks in :class:`AsyncHTTPProxyKMSConnect`:
+        ``proxy`` may be an :class:`ssl.SSLSocket`, which the event loop refuses
+        to read, so tasks would mean reimplementing the connect and CONNECT
+        handshake on streams.
         A KMS connection happens once per data key and is then cached, so the
         threads are short-lived and rare.
         """

--- a/pymongo/pool_shared.py
+++ b/pymongo/pool_shared.py
@@ -259,16 +259,19 @@ async def _async_create_connection(address: _Address, options: PoolOptions) -> s
         raise OSError("getaddrinfo failed")
 
 
-async def _async_configured_socket(
-    address: _Address, options: PoolOptions
+async def _async_wrap_socket_tls(
+    sock: socket.socket, address: _Address, options: PoolOptions
 ) -> Union[socket.socket, _sslConn]:
-    """Given (host, port) and PoolOptions, return a raw configured socket.
+    """Given a connected socket, (host, port), and PoolOptions, apply TLS.
+
+    The handshake, SNI, and certificate/hostname verification all target
+    ``address``, which may differ from the peer ``sock`` is connected to, for
+    example when ``sock`` tunnels through an HTTP proxy.
 
     Can raise socket.error, ConnectionFailure, or _CertificateError.
 
-    Sets socket's SSL and timeout options.
+    Sets the socket's SSL and timeout options.
     """
-    sock = await _async_create_connection(address, options)
     ssl_context = options._ssl_context
 
     if ssl_context is None:
@@ -313,6 +316,19 @@ async def _async_configured_socket(
 
     ssl_sock.settimeout(options.socket_timeout)
     return ssl_sock
+
+
+async def _async_configured_socket(
+    address: _Address, options: PoolOptions
+) -> Union[socket.socket, _sslConn]:
+    """Given (host, port) and PoolOptions, return a raw configured socket.
+
+    Can raise socket.error, ConnectionFailure, or _CertificateError.
+
+    Sets socket's SSL and timeout options.
+    """
+    sock = await _async_create_connection(address, options)
+    return await _async_wrap_socket_tls(sock, address, options)
 
 
 async def _configured_protocol_interface(
@@ -465,14 +481,19 @@ def _create_connection(address: _Address, options: PoolOptions) -> socket.socket
         raise OSError("getaddrinfo failed")
 
 
-def _configured_socket(address: _Address, options: PoolOptions) -> Union[socket.socket, _sslConn]:
-    """Given (host, port) and PoolOptions, return a raw configured socket.
+def _wrap_socket_tls(
+    sock: socket.socket, address: _Address, options: PoolOptions
+) -> Union[socket.socket, _sslConn]:
+    """Given a connected socket, (host, port), and PoolOptions, apply TLS.
+
+    The handshake, SNI, and certificate/hostname verification all target
+    ``address``, which may differ from the peer ``sock`` is connected to, for
+    example when ``sock`` tunnels through an HTTP proxy.
 
     Can raise socket.error, ConnectionFailure, or _CertificateError.
 
-    Sets socket's SSL and timeout options.
+    Sets the socket's SSL and timeout options.
     """
-    sock = _create_connection(address, options)
     ssl_context = options._ssl_context
 
     if ssl_context is None:
@@ -512,6 +533,17 @@ def _configured_socket(address: _Address, options: PoolOptions) -> Union[socket.
 
     ssl_sock.settimeout(options.socket_timeout)
     return ssl_sock
+
+
+def _configured_socket(address: _Address, options: PoolOptions) -> Union[socket.socket, _sslConn]:
+    """Given (host, port) and PoolOptions, return a raw configured socket.
+
+    Can raise socket.error, ConnectionFailure, or _CertificateError.
+
+    Sets socket's SSL and timeout options.
+    """
+    sock = _create_connection(address, options)
+    return _wrap_socket_tls(sock, address, options)
 
 
 def _configured_socket_interface(

--- a/pymongo/synchronous/encryption.py
+++ b/pymongo/synchronous/encryption.py
@@ -141,8 +141,7 @@ def _connect_kms(
         except Exception as exc:
             _raise_connection_failure(address, exc, timeout_details=_get_timeout_details(opts))
 
-    # TLS is applied here, against address, so verification targets the KMS
-    # host even when the socket terminates at a proxy.
+    # TLS targets address, not the peer, so verification follows the KMS host.
     result = kms_connect_callback(
         KMSConnectContext(host=address[0], port=cast(int, address[1]), timeout=timeout)
     )

--- a/pymongo/synchronous/encryption.py
+++ b/pymongo/synchronous/encryption.py
@@ -160,9 +160,12 @@ def _connect_kms(
         _close_rejected_kms_socket(sock)
         raise ConfigurationError(
             "kms_connect_callback must return a connected, unwrapped "
-            f"socket.socket, not {type(sock)}. TLS cannot be layered over an "
-            "already-wrapped socket; to reach the proxy over TLS, relay through "
-            "a socket.socketpair and return the plain end."
+            f"socket.socket, not {type(sock)}. An asyncio stream or transport, "
+            "including the object from transport.get_extra_info('socket'), "
+            "cannot be used; connect with loop.sock_connect instead. TLS cannot "
+            "be layered over an already-wrapped socket either; to reach the "
+            "proxy over TLS, relay through a socket.socketpair and return the "
+            "plain end."
         )
     # ssl.SSLContext.wrap_socket refuses a non-blocking socket, and a callback
     # has no reason to care which mode it left the socket in, so normalize it

--- a/pymongo/synchronous/encryption.py
+++ b/pymongo/synchronous/encryption.py
@@ -147,7 +147,7 @@ def _connect_kms(
     result = kms_connect_callback(
         KMSConnectContext(host=address[0], port=cast(int, address[1]), timeout=timeout)
     )
-    # _IS_SYNC is True in the generated synchronous flavor, where a regular
+    # _IS_SYNC is True in the generated synchronous module, where a regular
     # function is the correct thing to pass and nothing is awaited.
     if not _IS_SYNC and not inspect.isawaitable(result):
         _close_rejected_kms_socket(result)

--- a/pymongo/synchronous/encryption.py
+++ b/pymongo/synchronous/encryption.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import contextlib
 import enum
+import inspect
 import socket
 import ssl
 import time as time  # noqa: PLC0414 # needed in sync version
@@ -123,6 +124,19 @@ class _KMSCallbackContractError(Exception):
     """
 
 
+def _close_rejected_kms_socket(obj: Any) -> None:
+    """Close a rejected kms_connect_callback return value, if it can be closed.
+
+    The caller may have handed us a live socket, and nothing else will close it:
+    _connect_kms raises before its result reaches the caller's ``finally``. The
+    value can be anything a user returned, so closing is strictly best effort.
+    """
+    close = getattr(obj, "close", None)
+    if callable(close):
+        with contextlib.suppress(Exception):
+            close()
+
+
 def _connect_kms(
     address: _Address,
     opts: PoolOptions,
@@ -138,10 +152,25 @@ def _connect_kms(
     # Let the caller open the connection, then apply TLS ourselves so that SNI
     # and certificate verification still target the KMS host even when the
     # socket actually terminates at a proxy.
-    sock = kms_connect_callback(
+    result = kms_connect_callback(
         KMSConnectContext(host=address[0], port=cast(int, address[1]), timeout=timeout)
     )
+    # _IS_SYNC is True in the generated synchronous flavor, where a regular
+    # function is the correct thing to pass and nothing is awaited.
+    if not _IS_SYNC and not inspect.isawaitable(result):
+        _close_rejected_kms_socket(result)
+        # "async" and "def" are deliberately split across the next two source
+        # lines: tools/synchro.py deletes "async " from any line that spells
+        # those two words together, which would garble this message in the
+        # generated synchronous file even though the branch never runs there.
+        raise _KMSCallbackContractError(
+            "kms_connect_callback must be a coroutine function (an 'async"
+            " def') for the async driver, but calling it returned "
+            f"{type(result)}, which is not awaitable."
+        )
+    sock = result
     if not isinstance(sock, socket.socket) or isinstance(sock, ssl.SSLSocket):
+        _close_rejected_kms_socket(sock)
         raise _KMSCallbackContractError(
             "kms_connect_callback must return a connected, unwrapped "
             f"socket.socket, not {type(sock)}. TLS cannot be layered over an "

--- a/pymongo/synchronous/encryption.py
+++ b/pymongo/synchronous/encryption.py
@@ -116,14 +116,6 @@ _DATA_KEY_OPTS: CodecOptions[dict[str, Any]] = CodecOptions(
 _KEY_VAULT_OPTS = CodecOptions(document_class=RawBSONDocument)
 
 
-class _KMSCallbackContractError(Exception):
-    """Raised when a kms_connect_callback violates its contract.
-
-    Unlike a network error from the callback, this is a programming error, so
-    it is never retried.
-    """
-
-
 def _close_rejected_kms_socket(obj: Any) -> None:
     """Close a rejected kms_connect_callback return value, if it can be closed.
 
@@ -159,19 +151,14 @@ def _connect_kms(
     # function is the correct thing to pass and nothing is awaited.
     if not _IS_SYNC and not inspect.isawaitable(result):
         _close_rejected_kms_socket(result)
-        # "async" and "def" are deliberately split across the next two source
-        # lines: tools/synchro.py deletes "async " from any line that spells
-        # those two words together, which would garble this message in the
-        # generated synchronous file even though the branch never runs there.
-        raise _KMSCallbackContractError(
-            "kms_connect_callback must be a coroutine function (an 'async"
-            " def') for the async driver, but calling it returned "
-            f"{type(result)}, which is not awaitable."
+        raise ConfigurationError(
+            "kms_connect_callback must be a coroutine function for the async "
+            f"API, but calling it returned {type(result)}, which is not awaitable."
         )
     sock = result
     if not isinstance(sock, socket.socket) or isinstance(sock, ssl.SSLSocket):
         _close_rejected_kms_socket(sock)
-        raise _KMSCallbackContractError(
+        raise ConfigurationError(
             "kms_connect_callback must return a connected, unwrapped "
             f"socket.socket, not {type(sock)}. TLS cannot be layered over an "
             "already-wrapped socket; to reach the proxy over TLS, relay through "
@@ -302,7 +289,7 @@ class _EncryptionIO(MongoCryptCallback):  # type: ignore[misc]
                 conn.close()
         except MongoCryptError:
             raise  # Propagate MongoCryptError errors directly.
-        except _KMSCallbackContractError:
+        except ConfigurationError:
             raise  # A callback contract violation is not transient.
         except Exception as exc:
             remaining = _csot.remaining()
@@ -739,7 +726,7 @@ class ClientEncryption(Generic[_DocumentType]):
             KMS host, used to route KMS requests through an HTTP proxy. It
             receives a :class:`~pymongo.encryption_options.KMSConnectContext`
             and returns a connected, unwrapped :class:`socket.socket`; the
-            driver then performs the KMS TLS handshake over it. Must be a regular function.
+            driver then performs the KMS TLS handshake over it.
             See :class:`~pymongo.encryption_options.KMSConnectContext` for a worked
             HTTP ``CONNECT`` example. Defaults to ``None``, meaning the driver
             connects to KMS hosts directly.

--- a/pymongo/synchronous/encryption.py
+++ b/pymongo/synchronous/encryption.py
@@ -710,9 +710,8 @@ class ClientEncryption(Generic[_DocumentType]):
             KMS host, used to route KMS requests through an HTTP proxy. It
             receives a :class:`~pymongo.encryption_options.KMSConnectContext`
             and returns a connected, unwrapped :class:`socket.socket`; the
-            driver then performs the KMS TLS handshake over it. Must be a
-            coroutine function. See
-            :class:`~pymongo.encryption_options.KMSConnectContext` for a worked
+            driver then performs the KMS TLS handshake over it. Must be a regular function.
+            See :class:`~pymongo.encryption_options.KMSConnectContext` for a worked
             HTTP ``CONNECT`` example. Defaults to ``None``, meaning the driver
             connects to KMS hosts directly.
 

--- a/pymongo/synchronous/encryption.py
+++ b/pymongo/synchronous/encryption.py
@@ -636,6 +636,7 @@ class ClientEncryption(Generic[_DocumentType]):
         codec_options: CodecOptions[_DocumentTypeArg],
         kms_tls_options: Optional[Mapping[str, Any]] = None,
         key_expiration_ms: Optional[int] = None,
+        kms_connect_callback: Optional[KMSConnectCallback] = None,
     ) -> None:
         """Explicit client-side field level encryption.
 
@@ -705,7 +706,18 @@ class ClientEncryption(Generic[_DocumentType]):
         :param key_expiration_ms: The cache expiration time for data encryption keys.
             Defaults to ``None`` which defers to libmongocrypt's default which is currently 60000.
             Set to 0 to disable key expiration.
+        :param kms_connect_callback: A callable that opens the connection to a
+            KMS host, used to route KMS requests through an HTTP proxy. It
+            receives a :class:`~pymongo.encryption_options.KMSConnectContext`
+            and returns a connected, unwrapped :class:`socket.socket`; the
+            driver then performs the KMS TLS handshake over it. Must be a
+            coroutine function. See
+            :class:`~pymongo.encryption_options.KMSConnectContext` for a worked
+            HTTP ``CONNECT`` example. Defaults to ``None``, meaning the driver
+            connects to KMS hosts directly.
 
+        .. versionchanged:: 4.18
+           Added the `kms_connect_callback` parameter.
         .. versionchanged:: 4.12
            Added the `key_expiration_ms` parameter.
         .. versionchanged:: 4.0
@@ -745,6 +757,7 @@ class ClientEncryption(Generic[_DocumentType]):
             key_vault_namespace,
             kms_tls_options=kms_tls_options,
             key_expiration_ms=key_expiration_ms,
+            kms_connect_callback=kms_connect_callback,
         )
         self._kms_ssl_contexts = _parse_kms_tls_options(opts._kms_tls_options, _IS_SYNC)
         self._io_callbacks: Optional[_EncryptionIO] = _EncryptionIO(

--- a/pymongo/synchronous/encryption.py
+++ b/pymongo/synchronous/encryption.py
@@ -141,32 +141,26 @@ def _connect_kms(
         except Exception as exc:
             _raise_connection_failure(address, exc, timeout_details=_get_timeout_details(opts))
 
-    # Let the caller open the connection, then apply TLS ourselves so that SNI
-    # and certificate verification still target the KMS host even when the
-    # socket actually terminates at a proxy.
+    # TLS is applied here, against address, so verification targets the KMS
+    # host even when the socket terminates at a proxy.
     result = kms_connect_callback(
         KMSConnectContext(host=address[0], port=cast(int, address[1]), timeout=timeout)
     )
-    # _IS_SYNC is True in the generated synchronous module, where a regular
-    # function is the correct thing to pass and nothing is awaited.
+    # The synchronous module takes a regular function and awaits nothing.
     if not _IS_SYNC and not inspect.isawaitable(result):
         _close_rejected_kms_socket(result)
         raise ConfigurationError(
             "kms_connect_callback must be a coroutine function for the async "
-            f"API, but calling it returned {type(result)}, which is not awaitable."
+            f"API, but returned {type(result)}."
         )
     sock = result
     if not isinstance(sock, socket.socket) or isinstance(sock, ssl.SSLSocket):
         _close_rejected_kms_socket(sock)
         raise ConfigurationError(
             "kms_connect_callback must return a connected, unwrapped "
-            f"socket.socket, not {type(sock)}. Streams, transports and "
-            "transport sockets cannot be used; try loop.sock_connect. For a "
-            "TLS proxy, relay through a socket.socketpair and return the plain end."
+            f"socket.socket, not {type(sock)}; consider HTTPProxyKMSConnect."
         )
-    # ssl.SSLContext.wrap_socket refuses a non-blocking socket, and a callback
-    # has no reason to care which mode it left the socket in, so normalize it
-    # here rather than pushing the requirement onto the caller.
+    # wrap_socket refuses a non-blocking socket, so normalize the mode here.
     sock.settimeout(opts.socket_timeout)
     try:
         return _wrap_socket_tls(sock, address, opts)

--- a/pymongo/synchronous/encryption.py
+++ b/pymongo/synchronous/encryption.py
@@ -160,12 +160,9 @@ def _connect_kms(
         _close_rejected_kms_socket(sock)
         raise ConfigurationError(
             "kms_connect_callback must return a connected, unwrapped "
-            f"socket.socket, not {type(sock)}. An asyncio stream or transport, "
-            "including the object from transport.get_extra_info('socket'), "
-            "cannot be used; connect with loop.sock_connect instead. TLS cannot "
-            "be layered over an already-wrapped socket either; to reach the "
-            "proxy over TLS, relay through a socket.socketpair and return the "
-            "plain end."
+            f"socket.socket, not {type(sock)}. Streams, transports and "
+            "transport sockets cannot be used; try loop.sock_connect. For a "
+            "TLS proxy, relay through a socket.socketpair and return the plain end."
         )
     # ssl.SSLContext.wrap_socket refuses a non-blocking socket, and a callback
     # has no reason to care which mode it left the socket in, so normalize it

--- a/pymongo/synchronous/encryption.py
+++ b/pymongo/synchronous/encryption.py
@@ -724,10 +724,11 @@ class ClientEncryption(Generic[_DocumentType]):
             KMS host, used to route KMS requests through an HTTP proxy. It
             receives a :class:`~pymongo.encryption_options.KMSConnectContext`
             and returns a connected, unwrapped :class:`socket.socket`; the
-            driver then performs the KMS TLS handshake over it.
-            See :class:`~pymongo.encryption_options.KMSConnectContext` for a worked
-            HTTP ``CONNECT`` example. Defaults to ``None``, meaning the driver
-            connects to KMS hosts directly.
+            driver then performs the KMS TLS handshake over it. For an ordinary
+            HTTP proxy, pass
+            :class:`~pymongo.encryption_options.HTTPProxyKMSConnect`.
+            Defaults to ``None``, meaning the driver connects to KMS hosts
+            directly.
 
         .. versionchanged:: 4.18
            Added the `kms_connect_callback` parameter.

--- a/pymongo/synchronous/encryption.py
+++ b/pymongo/synchronous/encryption.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import contextlib
 import enum
 import socket
+import ssl
 import time as time  # noqa: PLC0414 # needed in sync version
 import uuid
 import weakref
@@ -59,6 +60,8 @@ from pymongo.common import CONNECT_TIMEOUT
 from pymongo.daemon import _spawn_daemon
 from pymongo.encryption_options import (
     AutoEncryptionOpts,
+    KMSConnectCallback,
+    KMSConnectContext,
     RangeOpts,
     TextOpts,
     check_min_pymongocrypt,
@@ -78,6 +81,7 @@ from pymongo.pool_options import PoolOptions
 from pymongo.pool_shared import (
     _configured_socket,
     _raise_connection_failure,
+    _wrap_socket_tls,
 )
 from pymongo.read_concern import ReadConcern
 from pymongo.results import BulkWriteResult, DeleteResult
@@ -111,9 +115,41 @@ _DATA_KEY_OPTS: CodecOptions[dict[str, Any]] = CodecOptions(
 _KEY_VAULT_OPTS = CodecOptions(document_class=RawBSONDocument)
 
 
-def _connect_kms(address: _Address, opts: PoolOptions) -> Union[socket.socket, _sslConn]:
+class _KMSCallbackContractError(Exception):
+    """Raised when a kms_connect_callback violates its contract.
+
+    Unlike a network error from the callback, this is a programming error, so
+    it is never retried.
+    """
+
+
+def _connect_kms(
+    address: _Address,
+    opts: PoolOptions,
+    kms_connect_callback: Optional[KMSConnectCallback] = None,
+    timeout: Optional[float] = None,
+) -> Union[socket.socket, _sslConn]:
+    if kms_connect_callback is None:
+        try:
+            return _configured_socket(address, opts)
+        except Exception as exc:
+            _raise_connection_failure(address, exc, timeout_details=_get_timeout_details(opts))
+
+    # Let the caller open the connection, then apply TLS ourselves so that SNI
+    # and certificate verification still target the KMS host even when the
+    # socket actually terminates at a proxy.
+    sock = kms_connect_callback(
+        KMSConnectContext(host=address[0], port=cast(int, address[1]), timeout=timeout)
+    )
+    if not isinstance(sock, socket.socket) or isinstance(sock, ssl.SSLSocket):
+        raise _KMSCallbackContractError(
+            "kms_connect_callback must return a connected, unwrapped "
+            f"socket.socket, not {type(sock)}. TLS cannot be layered over an "
+            "already-wrapped socket; to reach the proxy over TLS, relay through "
+            "a socket.socketpair and return the plain end."
+        )
     try:
-        return _configured_socket(address, opts)
+        return _wrap_socket_tls(sock, address, opts)
     except Exception as exc:
         _raise_connection_failure(address, exc, timeout_details=_get_timeout_details(opts))
 
@@ -196,7 +232,12 @@ class _EncryptionIO(MongoCryptCallback):  # type: ignore[misc]
             sleep_sec = float(sleep_u) / 1e6
             time.sleep(sleep_sec)
         try:
-            conn = _connect_kms(address, opts)
+            conn = _connect_kms(
+                address,
+                opts,
+                self.opts._kms_connect_callback,
+                connect_timeout,
+            )
             try:
                 sendall(conn, message)
                 while kms_context.bytes_needed > 0:
@@ -232,6 +273,8 @@ class _EncryptionIO(MongoCryptCallback):  # type: ignore[misc]
                 conn.close()
         except MongoCryptError:
             raise  # Propagate MongoCryptError errors directly.
+        except _KMSCallbackContractError:
+            raise  # A callback contract violation is not transient.
         except Exception as exc:
             remaining = _csot.remaining()
             if isinstance(exc, NetworkTimeout) or (remaining is not None and remaining <= 0):

--- a/pymongo/synchronous/encryption.py
+++ b/pymongo/synchronous/encryption.py
@@ -164,6 +164,10 @@ def _connect_kms(
             "already-wrapped socket; to reach the proxy over TLS, relay through "
             "a socket.socketpair and return the plain end."
         )
+    # ssl.SSLContext.wrap_socket refuses a non-blocking socket, and a callback
+    # has no reason to care which mode it left the socket in, so normalize it
+    # here rather than pushing the requirement onto the caller.
+    sock.settimeout(opts.socket_timeout)
     try:
         return _wrap_socket_tls(sock, address, opts)
     except Exception as exc:

--- a/test/asynchronous/test_encryption.py
+++ b/test/asynchronous/test_encryption.py
@@ -341,6 +341,22 @@ class TestKmsConnectCallbackUnit(AsyncPyMongoTestCase):
         self.addCleanup(conn.close)
         self.assertIsNotNone(conn.gettimeout())
 
+    async def test_asyncio_transport_socket_is_rejected(self):
+        # transport.get_extra_info("socket") returns an asyncio TransportSocket,
+        # not a socket.socket, and the loop still owns it. Reject it with a
+        # message that names the mistake rather than failing later.
+        from asyncio.trsock import TransportSocket
+
+        left, right = socket.socketpair()
+        self.addCleanup(left.close)
+        self.addCleanup(right.close)
+
+        async def callback(context):
+            return TransportSocket(left)
+
+        with self.assertRaisesRegex(ConfigurationError, "asyncio stream or transport"):
+            await _connect_kms(("kms.example.com", 443), self._pool_options(), callback, 10.0)
+
     async def test_network_error_from_callback_propagates(self):
         async def callback(context):
             raise OSError("proxy unreachable")

--- a/test/asynchronous/test_encryption.py
+++ b/test/asynchronous/test_encryption.py
@@ -87,6 +87,7 @@ from pymongo.errors import (
 )
 from pymongo.operations import InsertOne, ReplaceOne, UpdateOne
 from pymongo.pool_options import PoolOptions
+from pymongo.ssl_support import get_ssl_context
 from pymongo.write_concern import WriteConcern
 from test import (
     unittest,
@@ -304,6 +305,41 @@ class TestKmsConnectCallbackUnit(AsyncPyMongoTestCase):
         self.assertEqual(received[0].host, "kms.example.com")
         self.assertEqual(received[0].port, 443)
         self.assertEqual(received[0].timeout, 12.5)
+
+    async def test_non_blocking_socket_from_callback_is_accepted(self):
+        # ssl.SSLContext.wrap_socket refuses a non-blocking socket. The driver
+        # normalizes the mode so a callback need not care which mode it leaves
+        # the socket in. Without that, this handshake raises ValueError.
+        server_ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+        server_ctx.load_cert_chain(CLIENT_PEM)
+        listener = socket.socket()
+        listener.bind(("127.0.0.1", 0))
+        listener.listen(1)
+        self.addCleanup(listener.close)
+
+        def serve():
+            try:
+                conn, _ = listener.accept()
+                server_ctx.wrap_socket(conn, server_side=True).close()
+            except OSError:
+                pass
+
+        threading.Thread(target=serve, daemon=True).start()
+
+        # Build the context the way the driver does, so PoolOptions gets the
+        # flavor-correct type. Verification is off because the local test
+        # server's certificate is not what the driver would expect.
+        client_ctx = get_ssl_context(None, None, None, None, True, True, False, _IS_SYNC)
+        options = PoolOptions(connect_timeout=10, socket_timeout=10, ssl_context=client_ctx)
+
+        async def callback(context):
+            sock = socket.create_connection(listener.getsockname(), timeout=10)
+            sock.setblocking(False)
+            return sock
+
+        conn = await _connect_kms(listener.getsockname(), options, callback, 10.0)
+        self.addCleanup(conn.close)
+        self.assertIsNotNone(conn.gettimeout())
 
     async def test_network_error_from_callback_propagates(self):
         async def callback(context):

--- a/test/asynchronous/test_encryption.py
+++ b/test/asynchronous/test_encryption.py
@@ -295,8 +295,7 @@ class TestKmsConnectCallbackUnit(AsyncPyMongoTestCase):
             received.append(context)
             return left
 
-        # ssl_context=None returns the socket unchanged, so this also
-        # confirms a plain socket is accepted.
+        # ssl_context=None returns the socket unchanged, so a plain socket is accepted.
         conn = await _connect_kms(("kms.example.com", 443), self._pool_options(), callback, 12.5)
         self.assertIs(conn, left)
 
@@ -323,8 +322,7 @@ class TestKmsConnectCallbackUnit(AsyncPyMongoTestCase):
 
         threading.Thread(target=serve, daemon=True).start()
 
-        # Built as the driver does, for the flavor-correct type; the local
-        # cert would not verify.
+        # Built as the driver does, for the flavor-correct type; the local cert won't verify.
         client_ctx = get_ssl_context(None, None, None, None, True, True, False, _IS_SYNC)
         options = PoolOptions(connect_timeout=10, socket_timeout=10, ssl_context=client_ctx)
 

--- a/test/asynchronous/test_encryption.py
+++ b/test/asynchronous/test_encryption.py
@@ -313,6 +313,34 @@ class TestKmsConnectCallbackUnit(AsyncPyMongoTestCase):
         with self.assertRaises(OSError):
             await _connect_kms(("kms.example.com", 443), self._pool_options(), callback, 10.0)
 
+    @unittest.skipUnless(_HAVE_PYMONGOCRYPT, "pymongocrypt is not installed")
+    async def test_client_encryption_accepts_callback(self):
+        async def callback(context):
+            raise AssertionError("not called")
+
+        client = self.simple_client()
+        encryption = AsyncClientEncryption(
+            {"local": {"key": b"\x00" * 96}},
+            "keyvault.datakeys",
+            client,
+            OPTS,
+            kms_connect_callback=callback,
+        )
+        self.addAsyncCleanup(encryption.close)
+        self.assertIs(encryption._io_callbacks.opts._kms_connect_callback, callback)
+
+    @unittest.skipUnless(_HAVE_PYMONGOCRYPT, "pymongocrypt is not installed")
+    async def test_client_encryption_rejects_non_callable(self):
+        client = self.simple_client()
+        with self.assertRaisesRegex(TypeError, "kms_connect_callback must be callable"):
+            AsyncClientEncryption(
+                {"local": {"key": b"\x00" * 96}},
+                "keyvault.datakeys",
+                client,
+                OPTS,
+                kms_connect_callback="not-callable",  # type: ignore[arg-type]
+            )
+
 
 class TestClientOptions(AsyncPyMongoTestCase):
     async def test_default(self):
@@ -352,9 +380,15 @@ class AsyncEncryptionIntegrationTest(AsyncIntegrationTest):
         key_vault_client: AsyncMongoClient,
         codec_options: CodecOptions,
         kms_tls_options: Optional[Mapping[str, Any]] = None,
+        kms_connect_callback: Optional[Any] = None,
     ):
         client_encryption = AsyncClientEncryption(
-            kms_providers, key_vault_namespace, key_vault_client, codec_options, kms_tls_options
+            kms_providers,
+            key_vault_namespace,
+            key_vault_client,
+            codec_options,
+            kms_tls_options,
+            kms_connect_callback=kms_connect_callback,
         )
         self.addAsyncCleanup(client_encryption.close)
         return client_encryption
@@ -367,9 +401,15 @@ class AsyncEncryptionIntegrationTest(AsyncIntegrationTest):
         key_vault_client: AsyncMongoClient,
         codec_options: CodecOptions,
         kms_tls_options: Optional[Mapping[str, Any]] = None,
+        kms_connect_callback: Optional[Any] = None,
     ):
         client_encryption = AsyncClientEncryption(
-            kms_providers, key_vault_namespace, key_vault_client, codec_options, kms_tls_options
+            kms_providers,
+            key_vault_namespace,
+            key_vault_client,
+            codec_options,
+            kms_tls_options,
+            kms_connect_callback=kms_connect_callback,
         )
         return client_encryption
 

--- a/test/asynchronous/test_encryption.py
+++ b/test/asynchronous/test_encryption.py
@@ -71,7 +71,14 @@ from pymongo.asynchronous.encryption import (
 from pymongo.asynchronous.helpers import anext
 from pymongo.asynchronous.mongo_client import AsyncMongoClient
 from pymongo.cursor_shared import CursorType
-from pymongo.encryption_options import _HAVE_PYMONGOCRYPT, AutoEncryptionOpts, RangeOpts, TextOpts
+from pymongo.encryption_options import (
+    _HAVE_PYMONGOCRYPT,
+    AsyncHTTPProxyKMSConnect,
+    AutoEncryptionOpts,
+    KMSConnectContext,
+    RangeOpts,
+    TextOpts,
+)
 from pymongo.errors import (
     AutoReconnect,
     BulkWriteError,
@@ -348,6 +355,40 @@ class TestKmsConnectCallbackUnit(AsyncPyMongoTestCase):
 
         with self.assertRaisesRegex(ConfigurationError, "Streams, transports"):
             await _connect_kms(("kms.example.com", 443), self._pool_options(), callback, 10.0)
+
+    async def test_http_proxy_helper_tunnels_and_reports_refusal(self):
+        # Exercise the shipped helper against a stub proxy, so the CONNECT
+        # handshake is covered without KMS credentials.
+        accepted = []
+
+        def stub(listener, reply):
+            try:
+                conn, _ = listener.accept()
+            except OSError:
+                return
+            accepted.append(conn.recv(4096))
+            conn.sendall(reply)
+            conn.close()
+
+        def run_stub(reply):
+            listener = socket.socket()
+            listener.bind(("127.0.0.1", 0))
+            listener.listen(1)
+            self.addCleanup(listener.close)
+            threading.Thread(target=stub, args=(listener, reply), daemon=True).start()
+            return listener.getsockname()
+
+        host, port = run_stub(b"HTTP/1.1 200 Connection Established\r\n\r\n")
+        callback = AsyncHTTPProxyKMSConnect(host, port)
+        context = KMSConnectContext(host="kms.example.com", port=443, timeout=10)
+        sock = await callback(context)
+        self.addCleanup(sock.close)
+        self.assertIsInstance(sock, socket.socket)
+        self.assertEqual(accepted[0].split(b"\r\n")[0], b"CONNECT kms.example.com:443 HTTP/1.1")
+
+        host, port = run_stub(b"HTTP/1.1 407 Proxy Authentication Required\r\n\r\n")
+        with self.assertRaisesRegex(OSError, "refused CONNECT"):
+            await AsyncHTTPProxyKMSConnect(host, port)(context)
 
     async def test_network_error_from_callback_propagates(self):
         async def callback(context):
@@ -2111,60 +2152,6 @@ _AWS_MASTER_KEY = {
 }
 
 
-def _http_connect(context, proxy_port, proxy_ssl_context=None):
-    """Open an HTTP CONNECT tunnel to context.host:context.port.
-
-    Returns a plain socket. When proxy_ssl_context is given, the connection to
-    the proxy is TLS and the tunnel is bridged to a socketpair, because TLS
-    cannot be layered over an ssl.SSLSocket.
-    """
-    sock: socket.socket = socket.create_connection(
-        (_KMS_PROXY_HOST, proxy_port), timeout=context.timeout
-    )
-    try:
-        if proxy_ssl_context is not None:
-            sock = proxy_ssl_context.wrap_socket(sock, server_hostname=_KMS_PROXY_HOST)
-        target = f"{context.host}:{context.port}"
-        sock.sendall(f"CONNECT {target} HTTP/1.1\r\nHost: {target}\r\n\r\n".encode())
-        response = b""
-        while b"\r\n\r\n" not in response:
-            chunk = sock.recv(4096)
-            if not chunk:
-                raise OSError("proxy closed the connection before responding")
-            response += chunk
-        status = response.split(b"\r\n", 1)[0]
-        if not status.startswith(b"HTTP/1.1 200"):
-            raise OSError(f"proxy CONNECT failed: {status!r}")
-    except Exception:
-        sock.close()
-        raise
-
-    if proxy_ssl_context is None:
-        return sock
-
-    driver_side, relay_side = socket.socketpair()
-
-    def relay(src, dst):
-        try:
-            while True:
-                buf = src.recv(16384)
-                if not buf:
-                    break
-                dst.sendall(buf)
-        except OSError:
-            pass
-        finally:
-            for s in (src, dst):
-                try:
-                    s.close()
-                except OSError:
-                    pass
-
-    threading.Thread(target=relay, args=(relay_side, sock), daemon=True).start()
-    threading.Thread(target=relay, args=(sock, relay_side), daemon=True).start()
-    return driver_side
-
-
 # https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/tests/README.md#kms-connect-callback
 class TestKmsConnectCallbackProse(AsyncEncryptionIntegrationTest):
     @unittest.skipUnless(any(AWS_CREDS.values()), "AWS environment credentials are not set")
@@ -2174,17 +2161,14 @@ class TestKmsConnectCallbackProse(AsyncEncryptionIntegrationTest):
 
     async def plain_callback(self, context):
         self.callback_calls.append(context)
-        if not _IS_SYNC:
-            return await asyncio.to_thread(_http_connect, context, _KMS_PROXY_PORT)
-        return _http_connect(context, _KMS_PROXY_PORT)
+        return await AsyncHTTPProxyKMSConnect(_KMS_PROXY_HOST, _KMS_PROXY_PORT)(context)
 
     async def tls_callback(self, context):
         self.callback_calls.append(context)
         ctx = ssl.create_default_context(cafile=CA_PEM)
         ctx.check_hostname = False
-        if not _IS_SYNC:
-            return await asyncio.to_thread(_http_connect, context, _KMS_TLS_PROXY_PORT, ctx)
-        return _http_connect(context, _KMS_TLS_PROXY_PORT, ctx)
+        callback = AsyncHTTPProxyKMSConnect(_KMS_PROXY_HOST, _KMS_TLS_PROXY_PORT, ctx)
+        return await callback(context)
 
     async def proxy_request(self, method, path, tls=False):
         """Call the proxy's control endpoints and return the body."""
@@ -2323,9 +2307,7 @@ class TestKmsConnectCallbackProse(AsyncEncryptionIntegrationTest):
             state["calls"] += 1
             if state["calls"] == 1:
                 raise OSError("first attempt fails")
-            if not _IS_SYNC:
-                return await asyncio.to_thread(_http_connect, context, _KMS_PROXY_PORT)
-            return _http_connect(context, _KMS_PROXY_PORT)
+            return await AsyncHTTPProxyKMSConnect(_KMS_PROXY_HOST, _KMS_PROXY_PORT)(context)
 
         encryption = self.create_client_encryption(
             {"aws": AWS_CREDS},

--- a/test/asynchronous/test_encryption.py
+++ b/test/asynchronous/test_encryption.py
@@ -60,7 +60,13 @@ from bson.json_util import JSONOptions
 from bson.son import SON
 from pymongo import ReadPreference
 from pymongo.asynchronous import encryption
-from pymongo.asynchronous.encryption import Algorithm, AsyncClientEncryption, QueryType
+from pymongo.asynchronous.encryption import (
+    Algorithm,
+    AsyncClientEncryption,
+    QueryType,
+    _connect_kms,
+    _KMSCallbackContractError,
+)
 from pymongo.asynchronous.helpers import anext
 from pymongo.asynchronous.mongo_client import AsyncMongoClient
 from pymongo.cursor_shared import CursorType
@@ -79,6 +85,7 @@ from pymongo.errors import (
     WriteError,
 )
 from pymongo.operations import InsertOne, ReplaceOne, UpdateOne
+from pymongo.pool_options import PoolOptions
 from pymongo.write_concern import WriteConcern
 from test import (
     unittest,
@@ -241,6 +248,70 @@ class TestAutoEncryptionOpts(AsyncPyMongoTestCase):
         self.assertEqual(context.timeout, 9.5)
         with self.assertRaises(dataclasses.FrozenInstanceError):
             context.host = "evil.example.com"  # type: ignore[misc]
+
+
+class TestKmsConnectCallbackUnit(AsyncPyMongoTestCase):
+    """Contract checks for kms_connect_callback that need no KMS server."""
+
+    @staticmethod
+    def _pool_options():
+        return PoolOptions(connect_timeout=10, socket_timeout=10, ssl_context=None)
+
+    async def test_non_socket_return_is_not_retried(self):
+        async def callback(context):
+            return "not-a-socket"
+
+        with self.assertRaisesRegex(_KMSCallbackContractError, "must return a connected"):
+            await _connect_kms(("kms.example.com", 443), self._pool_options(), callback, 10.0)
+
+    async def test_already_wrapped_socket_is_rejected(self):
+        # ssl.SSLSocket subclasses socket.socket, but wrap_socket cannot layer
+        # TLS over it, so it must be rejected with an actionable message rather
+        # than failing later with an opaque handshake error.
+        ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_NONE
+        left, right = socket.socketpair()
+        self.addCleanup(right.close)
+        # do_handshake_on_connect=False means no peer is needed to produce a
+        # genuine ssl.SSLSocket.
+        wrapped = ctx.wrap_socket(left, do_handshake_on_connect=False, server_hostname="x")
+        self.addCleanup(wrapped.close)
+
+        async def callback(context):
+            return wrapped
+
+        with self.assertRaisesRegex(_KMSCallbackContractError, "unwrapped"):
+            await _connect_kms(("kms.example.com", 443), self._pool_options(), callback, 10.0)
+
+    async def test_context_receives_host_port_and_timeout(self):
+        received = []
+        left, right = socket.socketpair()
+        self.addCleanup(left.close)
+        self.addCleanup(right.close)
+
+        async def callback(context):
+            received.append(context)
+            return left
+
+        # With ssl_context=None the socket is returned unchanged, which also
+        # confirms a plain socket is accepted.
+        conn = await _connect_kms(("kms.example.com", 443), self._pool_options(), callback, 12.5)
+        self.assertIs(conn, left)
+
+        self.assertEqual(len(received), 1)
+        self.assertEqual(received[0].host, "kms.example.com")
+        self.assertEqual(received[0].port, 443)
+        self.assertEqual(received[0].timeout, 12.5)
+
+    async def test_network_error_from_callback_propagates(self):
+        async def callback(context):
+            raise OSError("proxy unreachable")
+
+        # Not wrapped in _KMSCallbackContractError, so kms_request's broad
+        # handler can treat it as transient and let libmongocrypt retry.
+        with self.assertRaises(OSError):
+            await _connect_kms(("kms.example.com", 443), self._pool_options(), callback, 10.0)
 
 
 class TestClientOptions(AsyncPyMongoTestCase):

--- a/test/asynchronous/test_encryption.py
+++ b/test/asynchronous/test_encryption.py
@@ -270,15 +270,13 @@ class TestKmsConnectCallbackUnit(AsyncPyMongoTestCase):
             await _connect_kms(("kms.example.com", 443), self._pool_options(), callback, 10.0)
 
     async def test_already_wrapped_socket_is_rejected(self):
-        # ssl.SSLSocket subclasses socket.socket, but wrap_socket cannot layer
-        # TLS over it, so it needs its own rejection.
+        # ssl.SSLSocket passes isinstance but cannot be TLS-wrapped again.
         ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
         ctx.check_hostname = False
         ctx.verify_mode = ssl.CERT_NONE
         left, right = socket.socketpair()
         self.addCleanup(right.close)
-        # do_handshake_on_connect=False means no peer is needed to produce a
-        # genuine ssl.SSLSocket.
+        # No peer needed to produce a genuine ssl.SSLSocket.
         wrapped = ctx.wrap_socket(left, do_handshake_on_connect=False, server_hostname="x")
         self.addCleanup(wrapped.close)
 
@@ -298,7 +296,7 @@ class TestKmsConnectCallbackUnit(AsyncPyMongoTestCase):
             received.append(context)
             return left
 
-        # With ssl_context=None the socket is returned unchanged, which also
+        # ssl_context=None returns the socket unchanged, so this also
         # confirms a plain socket is accepted.
         conn = await _connect_kms(("kms.example.com", 443), self._pool_options(), callback, 12.5)
         self.assertIs(conn, left)
@@ -309,8 +307,7 @@ class TestKmsConnectCallbackUnit(AsyncPyMongoTestCase):
         self.assertEqual(received[0].timeout, 12.5)
 
     async def test_non_blocking_socket_from_callback_is_accepted(self):
-        # wrap_socket refuses a non-blocking socket; the driver normalizes the
-        # mode. Without that, this handshake raises ValueError.
+        # Without the driver normalizing the mode, this raises ValueError.
         server_ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
         server_ctx.load_cert_chain(CLIENT_PEM)
         listener = socket.socket()
@@ -327,8 +324,8 @@ class TestKmsConnectCallbackUnit(AsyncPyMongoTestCase):
 
         threading.Thread(target=serve, daemon=True).start()
 
-        # Built the way the driver does, so PoolOptions gets the flavor-correct
-        # type. Verification is off: the local cert is not what it expects.
+        # Built as the driver does, for the flavor-correct type; the local
+        # cert would not verify.
         client_ctx = get_ssl_context(None, None, None, None, True, True, False, _IS_SYNC)
         options = PoolOptions(connect_timeout=10, socket_timeout=10, ssl_context=client_ctx)
 
@@ -342,8 +339,7 @@ class TestKmsConnectCallbackUnit(AsyncPyMongoTestCase):
         self.assertIsNotNone(conn.gettimeout())
 
     async def test_asyncio_transport_socket_is_rejected(self):
-        # transport.get_extra_info("socket") is an asyncio TransportSocket, not
-        # a socket.socket, and the loop still owns it.
+        # get_extra_info("socket") is a TransportSocket, not a socket.socket.
         from asyncio.trsock import TransportSocket
 
         left, right = socket.socketpair()
@@ -353,12 +349,11 @@ class TestKmsConnectCallbackUnit(AsyncPyMongoTestCase):
         async def callback(context):
             return TransportSocket(left)
 
-        with self.assertRaisesRegex(ConfigurationError, "Streams, transports"):
+        with self.assertRaisesRegex(ConfigurationError, "TransportSocket"):
             await _connect_kms(("kms.example.com", 443), self._pool_options(), callback, 10.0)
 
     async def test_http_proxy_helper_tunnels_and_reports_refusal(self):
-        # Exercise the shipped helper against a stub proxy, so the CONNECT
-        # handshake is covered without KMS credentials.
+        # Covers the CONNECT handshake without KMS credentials.
         accepted = []
 
         def stub(listener, reply):
@@ -394,8 +389,7 @@ class TestKmsConnectCallbackUnit(AsyncPyMongoTestCase):
         async def callback(context):
             raise OSError("proxy unreachable")
 
-        # Not a ConfigurationError, so kms_request's broad
-        # handler can treat it as transient and let libmongocrypt retry.
+        # Not a ConfigurationError, so kms_request retries it.
         with self.assertRaises(OSError):
             await _connect_kms(("kms.example.com", 443), self._pool_options(), callback, 10.0)
 
@@ -2188,8 +2182,7 @@ class TestKmsConnectCallbackProse(AsyncEncryptionIntegrationTest):
 
     async def connect_count(self, tls=False):
         body = await self.proxy_request("GET", "/metrics", tls=tls)
-        # The body is one "key value" pair per line. Only connect_count is
-        # required by the spec; the server also emits connect_target lines.
+        # One "key value" per line; the server also emits connect_target.
         for line in body.splitlines():
             key, _, value = line.partition(" ")
             if key == "connect_count":
@@ -2294,9 +2287,7 @@ class TestKmsConnectCallbackProse(AsyncEncryptionIntegrationTest):
 
         self.assertTrue(self.callback_calls, "callback was never invoked")
         for context in self.callback_calls:
-            # Only checks the spec's literal non-zero requirement, which
-            # cannot fail: timeoutMS does not tighten this value because
-            # explicit ClientEncryption operations set no CSOT deadline.
+            # Checks only the spec's non-zero requirement, which cannot fail.
             self.assertIsNotNone(context.timeout)
             self.assertGreater(context.timeout, 0)
 

--- a/test/asynchronous/test_encryption.py
+++ b/test/asynchronous/test_encryption.py
@@ -2263,6 +2263,11 @@ class TestKmsConnectCallbackProse(AsyncEncryptionIntegrationTest):
 
         self.assertTrue(self.callback_calls, "callback was never invoked")
         for context in self.callback_calls:
+            # This only checks the spec's literal requirement (a non-zero
+            # timeout). timeoutMS=1000 above does not currently tighten this
+            # value: explicit ClientEncryption operations establish no CSOT
+            # deadline, so this always falls back to the driver's default KMS
+            # connect timeout regardless of key_vault_client's timeoutMS.
             self.assertIsNotNone(context.timeout)
             self.assertGreater(context.timeout, 0)
 

--- a/test/asynchronous/test_encryption.py
+++ b/test/asynchronous/test_encryption.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import base64
 import copy
+import dataclasses
 import http.client
 import json
 import os
@@ -212,6 +213,34 @@ class TestAutoEncryptionOpts(AsyncPyMongoTestCase):
         ctx = _kms_ssl_contexts["kmip"]
         self.assertEqual(ctx.check_hostname, True)
         self.assertEqual(ctx.verify_mode, ssl.CERT_REQUIRED)
+
+    @unittest.skipUnless(_HAVE_PYMONGOCRYPT, "pymongocrypt is not installed")
+    async def test_init_kms_connect_callback(self):
+        from pymongo.encryption_options import KMSConnectContext
+
+        # Default is None.
+        opts = AutoEncryptionOpts({}, "k.d")
+        self.assertIsNone(opts._kms_connect_callback)
+
+        # A callable is accepted and stored unchanged.
+        async def callback(context):
+            raise AssertionError("not called")
+
+        opts = AutoEncryptionOpts({}, "k.d", kms_connect_callback=callback)
+        self.assertIs(opts._kms_connect_callback, callback)
+
+        # Non-callables are rejected eagerly.
+        for bad in [1, "not-callable", object()]:
+            with self.assertRaisesRegex(TypeError, "kms_connect_callback must be callable"):
+                AutoEncryptionOpts({}, "k.d", kms_connect_callback=bad)  # type: ignore[arg-type]
+
+        # The context is frozen and carries host, port, and timeout.
+        context = KMSConnectContext(host="kms.example.com", port=443, timeout=9.5)
+        self.assertEqual(context.host, "kms.example.com")
+        self.assertEqual(context.port, 443)
+        self.assertEqual(context.timeout, 9.5)
+        with self.assertRaises(dataclasses.FrozenInstanceError):
+            context.host = "evil.example.com"  # type: ignore[misc]
 
 
 class TestClientOptions(AsyncPyMongoTestCase):

--- a/test/asynchronous/test_encryption.py
+++ b/test/asynchronous/test_encryption.py
@@ -34,6 +34,7 @@ import threading
 import traceback
 import uuid
 import warnings
+from asyncio.trsock import TransportSocket
 from collections.abc import Mapping
 from threading import Thread
 from typing import Any, Optional
@@ -232,8 +233,6 @@ class TestAutoEncryptionOpts(AsyncPyMongoTestCase):
 
     @unittest.skipUnless(_HAVE_PYMONGOCRYPT, "pymongocrypt is not installed")
     async def test_init_kms_connect_callback(self):
-        from pymongo.encryption_options import KMSConnectContext
-
         opts = AutoEncryptionOpts({}, "k.d")
         self.assertIsNone(opts._kms_connect_callback)
 
@@ -340,8 +339,6 @@ class TestKmsConnectCallbackUnit(AsyncPyMongoTestCase):
 
     async def test_asyncio_transport_socket_is_rejected(self):
         # get_extra_info("socket") is a TransportSocket, not a socket.socket.
-        from asyncio.trsock import TransportSocket
-
         left, right = socket.socketpair()
         self.addCleanup(left.close)
         self.addCleanup(right.close)

--- a/test/asynchronous/test_encryption.py
+++ b/test/asynchronous/test_encryption.py
@@ -227,23 +227,19 @@ class TestAutoEncryptionOpts(AsyncPyMongoTestCase):
     async def test_init_kms_connect_callback(self):
         from pymongo.encryption_options import KMSConnectContext
 
-        # Default is None.
         opts = AutoEncryptionOpts({}, "k.d")
         self.assertIsNone(opts._kms_connect_callback)
 
-        # A callable is accepted and stored unchanged.
         async def callback(context):
             raise AssertionError("not called")
 
         opts = AutoEncryptionOpts({}, "k.d", kms_connect_callback=callback)
         self.assertIs(opts._kms_connect_callback, callback)
 
-        # Non-callables are rejected eagerly.
         for bad in [1, "not-callable", object()]:
             with self.assertRaisesRegex(TypeError, "kms_connect_callback must be callable"):
                 AutoEncryptionOpts({}, "k.d", kms_connect_callback=bad)  # type: ignore[arg-type]
 
-        # The context is frozen and carries host, port, and timeout.
         context = KMSConnectContext(host="kms.example.com", port=443, timeout=9.5)
         self.assertEqual(context.host, "kms.example.com")
         self.assertEqual(context.port, 443)
@@ -268,8 +264,7 @@ class TestKmsConnectCallbackUnit(AsyncPyMongoTestCase):
 
     async def test_already_wrapped_socket_is_rejected(self):
         # ssl.SSLSocket subclasses socket.socket, but wrap_socket cannot layer
-        # TLS over it, so it must be rejected with an actionable message rather
-        # than failing later with an opaque handshake error.
+        # TLS over it, so it needs its own rejection.
         ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
         ctx.check_hostname = False
         ctx.verify_mode = ssl.CERT_NONE
@@ -307,9 +302,8 @@ class TestKmsConnectCallbackUnit(AsyncPyMongoTestCase):
         self.assertEqual(received[0].timeout, 12.5)
 
     async def test_non_blocking_socket_from_callback_is_accepted(self):
-        # ssl.SSLContext.wrap_socket refuses a non-blocking socket. The driver
-        # normalizes the mode so a callback need not care which mode it leaves
-        # the socket in. Without that, this handshake raises ValueError.
+        # wrap_socket refuses a non-blocking socket; the driver normalizes the
+        # mode. Without that, this handshake raises ValueError.
         server_ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
         server_ctx.load_cert_chain(CLIENT_PEM)
         listener = socket.socket()
@@ -326,9 +320,8 @@ class TestKmsConnectCallbackUnit(AsyncPyMongoTestCase):
 
         threading.Thread(target=serve, daemon=True).start()
 
-        # Build the context the way the driver does, so PoolOptions gets the
-        # flavor-correct type. Verification is off because the local test
-        # server's certificate is not what the driver would expect.
+        # Built the way the driver does, so PoolOptions gets the flavor-correct
+        # type. Verification is off: the local cert is not what it expects.
         client_ctx = get_ssl_context(None, None, None, None, True, True, False, _IS_SYNC)
         options = PoolOptions(connect_timeout=10, socket_timeout=10, ssl_context=client_ctx)
 
@@ -342,9 +335,8 @@ class TestKmsConnectCallbackUnit(AsyncPyMongoTestCase):
         self.assertIsNotNone(conn.gettimeout())
 
     async def test_asyncio_transport_socket_is_rejected(self):
-        # transport.get_extra_info("socket") returns an asyncio TransportSocket,
-        # not a socket.socket, and the loop still owns it. Reject it with a
-        # message that names the mistake rather than failing later.
+        # transport.get_extra_info("socket") is an asyncio TransportSocket, not
+        # a socket.socket, and the loop still owns it.
         from asyncio.trsock import TransportSocket
 
         left, right = socket.socketpair()
@@ -354,7 +346,7 @@ class TestKmsConnectCallbackUnit(AsyncPyMongoTestCase):
         async def callback(context):
             return TransportSocket(left)
 
-        with self.assertRaisesRegex(ConfigurationError, "asyncio stream or transport"):
+        with self.assertRaisesRegex(ConfigurationError, "Streams, transports"):
             await _connect_kms(("kms.example.com", 443), self._pool_options(), callback, 10.0)
 
     async def test_network_error_from_callback_propagates(self):

--- a/test/asynchronous/test_encryption.py
+++ b/test/asynchronous/test_encryption.py
@@ -2250,6 +2250,10 @@ class TestKmsConnectCallbackProse(AsyncEncryptionIntegrationTest):
         with self.assertRaisesRegex(EncryptionError, "proxy is on fire"):
             await encryption.create_data_key("aws", master_key=_AWS_MASTER_KEY)
 
+    @unittest.skip(
+        "PYTHON-6037 ClientEncryption does not support timeoutMS, so the "
+        "callback always receives the default KMS connect timeout"
+    )
     async def test_05_callback_receives_timeout(self):
         key_vault_client = await self.async_rs_or_single_client(timeoutMS=1000)
         encryption = self.create_client_encryption(
@@ -2263,11 +2267,12 @@ class TestKmsConnectCallbackProse(AsyncEncryptionIntegrationTest):
 
         self.assertTrue(self.callback_calls, "callback was never invoked")
         for context in self.callback_calls:
-            # This only checks the spec's literal requirement (a non-zero
-            # timeout). timeoutMS=1000 above does not currently tighten this
-            # value: explicit ClientEncryption operations establish no CSOT
-            # deadline, so this always falls back to the driver's default KMS
-            # connect timeout regardless of key_vault_client's timeoutMS.
+            # Skipped: this would only check the spec's literal requirement
+            # (a non-zero timeout), which cannot fail here. timeoutMS=1000
+            # above does not tighten this value, because explicit
+            # ClientEncryption operations establish no CSOT deadline, so it
+            # always falls back to the driver's default KMS connect timeout.
+            # Un-skip once PYTHON-6037 adds timeoutMS to ClientEncryption.
             self.assertIsNotNone(context.timeout)
             self.assertGreater(context.timeout, 0)
 

--- a/test/asynchronous/test_encryption.py
+++ b/test/asynchronous/test_encryption.py
@@ -67,7 +67,6 @@ from pymongo.asynchronous.encryption import (
     AsyncClientEncryption,
     QueryType,
     _connect_kms,
-    _KMSCallbackContractError,
 )
 from pymongo.asynchronous.helpers import anext
 from pymongo.asynchronous.mongo_client import AsyncMongoClient
@@ -263,7 +262,7 @@ class TestKmsConnectCallbackUnit(AsyncPyMongoTestCase):
         async def callback(context):
             return "not-a-socket"
 
-        with self.assertRaisesRegex(_KMSCallbackContractError, "must return a connected"):
+        with self.assertRaisesRegex(ConfigurationError, "must return a connected"):
             await _connect_kms(("kms.example.com", 443), self._pool_options(), callback, 10.0)
 
     async def test_already_wrapped_socket_is_rejected(self):
@@ -283,7 +282,7 @@ class TestKmsConnectCallbackUnit(AsyncPyMongoTestCase):
         async def callback(context):
             return wrapped
 
-        with self.assertRaisesRegex(_KMSCallbackContractError, "unwrapped"):
+        with self.assertRaisesRegex(ConfigurationError, "unwrapped"):
             await _connect_kms(("kms.example.com", 443), self._pool_options(), callback, 10.0)
 
     async def test_context_receives_host_port_and_timeout(self):
@@ -310,7 +309,7 @@ class TestKmsConnectCallbackUnit(AsyncPyMongoTestCase):
         async def callback(context):
             raise OSError("proxy unreachable")
 
-        # Not wrapped in _KMSCallbackContractError, so kms_request's broad
+        # Not a ConfigurationError, so kms_request's broad
         # handler can treat it as transient and let libmongocrypt retry.
         with self.assertRaises(OSError):
             await _connect_kms(("kms.example.com", 443), self._pool_options(), callback, 10.0)

--- a/test/asynchronous/test_encryption.py
+++ b/test/asynchronous/test_encryption.py
@@ -2247,7 +2247,7 @@ class TestKmsConnectCallbackProse(AsyncEncryptionIntegrationTest):
             OPTS,
             kms_connect_callback=failing_callback,
         )
-        with self.assertRaises(EncryptionError):
+        with self.assertRaisesRegex(EncryptionError, "proxy is on fire"):
             await encryption.create_data_key("aws", master_key=_AWS_MASTER_KEY)
 
     async def test_05_callback_receives_timeout(self):

--- a/test/asynchronous/test_encryption.py
+++ b/test/asynchronous/test_encryption.py
@@ -2133,11 +2133,11 @@ class TestKmsTLSProse(AsyncEncryptionIntegrationTest):
             await self.client_encrypted.create_data_key("aws", master_key=key)
 
 
-_KMS_PROXY_HOST = "127.0.0.1"
-_KMS_PROXY_PORT = 9004
-_KMS_TLS_PROXY_PORT = 9005
+KMS_PROXY_HOST = "127.0.0.1"
+KMS_PROXY_PORT = 9004
+KMS_TLS_PROXY_PORT = 9005
 
-_AWS_MASTER_KEY = {
+AWS_MASTER_KEY = {
     "region": "us-east-1",
     "key": "arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0",
 }
@@ -2152,13 +2152,13 @@ class TestKmsConnectCallbackProse(AsyncEncryptionIntegrationTest):
 
     async def plain_callback(self, context):
         self.callback_calls.append(context)
-        return await AsyncHTTPProxyKMSConnect(_KMS_PROXY_HOST, _KMS_PROXY_PORT)(context)
+        return await AsyncHTTPProxyKMSConnect(KMS_PROXY_HOST, KMS_PROXY_PORT)(context)
 
     async def tls_callback(self, context):
         self.callback_calls.append(context)
         ctx = ssl.create_default_context(cafile=CA_PEM)
         ctx.check_hostname = False
-        callback = AsyncHTTPProxyKMSConnect(_KMS_PROXY_HOST, _KMS_TLS_PROXY_PORT, ctx)
+        callback = AsyncHTTPProxyKMSConnect(KMS_PROXY_HOST, KMS_TLS_PROXY_PORT, ctx)
         return await callback(context)
 
     async def proxy_request(self, method, path, tls=False):
@@ -2167,10 +2167,10 @@ class TestKmsConnectCallbackProse(AsyncEncryptionIntegrationTest):
             ctx = ssl.create_default_context(cafile=CA_PEM)
             ctx.check_hostname = False
             conn = http.client.HTTPSConnection(
-                f"{_KMS_PROXY_HOST}:{_KMS_TLS_PROXY_PORT}", context=ctx
+                f"{KMS_PROXY_HOST}:{KMS_TLS_PROXY_PORT}", context=ctx
             )
         else:
-            conn = http.client.HTTPConnection(f"{_KMS_PROXY_HOST}:{_KMS_PROXY_PORT}")
+            conn = http.client.HTTPConnection(f"{KMS_PROXY_HOST}:{KMS_PROXY_PORT}")
         try:
             conn.request(method, path)
             return conn.getresponse().read().decode()
@@ -2195,7 +2195,7 @@ class TestKmsConnectCallbackProse(AsyncEncryptionIntegrationTest):
             OPTS,
             kms_connect_callback=self.plain_callback,
         )
-        await encryption.create_data_key("aws", master_key=_AWS_MASTER_KEY)
+        await encryption.create_data_key("aws", master_key=AWS_MASTER_KEY)
         self.assertGreaterEqual(await self.connect_count(), 1)
 
     async def test_02_https_proxy(self):
@@ -2207,7 +2207,7 @@ class TestKmsConnectCallbackProse(AsyncEncryptionIntegrationTest):
             OPTS,
             kms_connect_callback=self.tls_callback,
         )
-        await encryption.create_data_key("aws", master_key=_AWS_MASTER_KEY)
+        await encryption.create_data_key("aws", master_key=AWS_MASTER_KEY)
         self.assertGreaterEqual(await self.connect_count(tls=True), 1)
 
     async def test_03_auto_encryption_through_proxy(self):
@@ -2221,7 +2221,7 @@ class TestKmsConnectCallbackProse(AsyncEncryptionIntegrationTest):
             OPTS,
             kms_connect_callback=self.plain_callback,
         )
-        data_key_id = await encryption.create_data_key("aws", master_key=_AWS_MASTER_KEY)
+        data_key_id = await encryption.create_data_key("aws", master_key=AWS_MASTER_KEY)
         schema = {
             "bsonType": "object",
             "properties": {
@@ -2265,7 +2265,7 @@ class TestKmsConnectCallbackProse(AsyncEncryptionIntegrationTest):
             kms_connect_callback=failing_callback,
         )
         with self.assertRaisesRegex(EncryptionError, "proxy is on fire"):
-            await encryption.create_data_key("aws", master_key=_AWS_MASTER_KEY)
+            await encryption.create_data_key("aws", master_key=AWS_MASTER_KEY)
 
     @unittest.skip(
         "PYTHON-6037 ClientEncryption does not support timeoutMS, so the "
@@ -2280,7 +2280,7 @@ class TestKmsConnectCallbackProse(AsyncEncryptionIntegrationTest):
             OPTS,
             kms_connect_callback=self.plain_callback,
         )
-        await encryption.create_data_key("aws", master_key=_AWS_MASTER_KEY)
+        await encryption.create_data_key("aws", master_key=AWS_MASTER_KEY)
 
         self.assertTrue(self.callback_calls, "callback was never invoked")
         for context in self.callback_calls:
@@ -2295,7 +2295,7 @@ class TestKmsConnectCallbackProse(AsyncEncryptionIntegrationTest):
             state["calls"] += 1
             if state["calls"] == 1:
                 raise OSError("first attempt fails")
-            return await AsyncHTTPProxyKMSConnect(_KMS_PROXY_HOST, _KMS_PROXY_PORT)(context)
+            return await AsyncHTTPProxyKMSConnect(KMS_PROXY_HOST, KMS_PROXY_PORT)(context)
 
         encryption = self.create_client_encryption(
             {"aws": AWS_CREDS},
@@ -2304,7 +2304,7 @@ class TestKmsConnectCallbackProse(AsyncEncryptionIntegrationTest):
             OPTS,
             kms_connect_callback=flaky_callback,
         )
-        await encryption.create_data_key("aws", master_key=_AWS_MASTER_KEY)
+        await encryption.create_data_key("aws", master_key=AWS_MASTER_KEY)
         self.assertGreaterEqual(state["calls"], 2)
 
 

--- a/test/asynchronous/test_encryption.py
+++ b/test/asynchronous/test_encryption.py
@@ -2267,12 +2267,9 @@ class TestKmsConnectCallbackProse(AsyncEncryptionIntegrationTest):
 
         self.assertTrue(self.callback_calls, "callback was never invoked")
         for context in self.callback_calls:
-            # Skipped: this would only check the spec's literal requirement
-            # (a non-zero timeout), which cannot fail here. timeoutMS=1000
-            # above does not tighten this value, because explicit
-            # ClientEncryption operations establish no CSOT deadline, so it
-            # always falls back to the driver's default KMS connect timeout.
-            # Un-skip once PYTHON-6037 adds timeoutMS to ClientEncryption.
+            # Only checks the spec's literal non-zero requirement, which
+            # cannot fail: timeoutMS does not tighten this value because
+            # explicit ClientEncryption operations set no CSOT deadline.
             self.assertIsNotNone(context.timeout)
             self.assertGreater(context.timeout, 0)
 

--- a/test/asynchronous/test_encryption.py
+++ b/test/asynchronous/test_encryption.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import base64
 import copy
 import dataclasses
@@ -29,6 +30,7 @@ import socketserver
 import ssl
 import sys
 import textwrap
+import threading
 import traceback
 import uuid
 import warnings
@@ -2054,6 +2056,236 @@ class TestKmsTLSProse(AsyncEncryptionIntegrationTest):
             EncryptionError, "IP address mismatch|wronghost|IPAddressMismatch|Certificate"
         ):
             await self.client_encrypted.create_data_key("aws", master_key=key)
+
+
+_KMS_PROXY_HOST = "127.0.0.1"
+_KMS_PROXY_PORT = 9004
+_KMS_TLS_PROXY_PORT = 9005
+
+_AWS_MASTER_KEY = {
+    "region": "us-east-1",
+    "key": "arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0",
+}
+
+
+def _http_connect(context, proxy_port, proxy_ssl_context=None):
+    """Open an HTTP CONNECT tunnel to context.host:context.port.
+
+    Returns a plain socket. When proxy_ssl_context is given, the connection to
+    the proxy is TLS and the tunnel is bridged to a socketpair, because TLS
+    cannot be layered over an ssl.SSLSocket.
+    """
+    sock: socket.socket = socket.create_connection(
+        (_KMS_PROXY_HOST, proxy_port), timeout=context.timeout
+    )
+    try:
+        if proxy_ssl_context is not None:
+            sock = proxy_ssl_context.wrap_socket(sock, server_hostname=_KMS_PROXY_HOST)
+        target = f"{context.host}:{context.port}"
+        sock.sendall(f"CONNECT {target} HTTP/1.1\r\nHost: {target}\r\n\r\n".encode())
+        response = b""
+        while b"\r\n\r\n" not in response:
+            chunk = sock.recv(4096)
+            if not chunk:
+                raise OSError("proxy closed the connection before responding")
+            response += chunk
+        status = response.split(b"\r\n", 1)[0]
+        if not status.startswith(b"HTTP/1.1 200"):
+            raise OSError(f"proxy CONNECT failed: {status!r}")
+    except Exception:
+        sock.close()
+        raise
+
+    if proxy_ssl_context is None:
+        return sock
+
+    driver_side, relay_side = socket.socketpair()
+
+    def relay(src, dst):
+        try:
+            while True:
+                buf = src.recv(16384)
+                if not buf:
+                    break
+                dst.sendall(buf)
+        except OSError:
+            pass
+        finally:
+            for s in (src, dst):
+                try:
+                    s.close()
+                except OSError:
+                    pass
+
+    threading.Thread(target=relay, args=(relay_side, sock), daemon=True).start()
+    threading.Thread(target=relay, args=(sock, relay_side), daemon=True).start()
+    return driver_side
+
+
+# https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/tests/README.md#kms-connect-callback
+class TestKmsConnectCallbackProse(AsyncEncryptionIntegrationTest):
+    @unittest.skipUnless(any(AWS_CREDS.values()), "AWS environment credentials are not set")
+    async def asyncSetUp(self):
+        await super().asyncSetUp()
+        self.callback_calls: list[Any] = []
+
+    async def plain_callback(self, context):
+        self.callback_calls.append(context)
+        if not _IS_SYNC:
+            return await asyncio.to_thread(_http_connect, context, _KMS_PROXY_PORT)
+        return _http_connect(context, _KMS_PROXY_PORT)
+
+    async def tls_callback(self, context):
+        self.callback_calls.append(context)
+        ctx = ssl.create_default_context(cafile=CA_PEM)
+        ctx.check_hostname = False
+        if not _IS_SYNC:
+            return await asyncio.to_thread(_http_connect, context, _KMS_TLS_PROXY_PORT, ctx)
+        return _http_connect(context, _KMS_TLS_PROXY_PORT, ctx)
+
+    async def proxy_request(self, method, path, tls=False):
+        """Call the proxy's control endpoints and return the body."""
+        if tls:
+            ctx = ssl.create_default_context(cafile=CA_PEM)
+            ctx.check_hostname = False
+            conn = http.client.HTTPSConnection(
+                f"{_KMS_PROXY_HOST}:{_KMS_TLS_PROXY_PORT}", context=ctx
+            )
+        else:
+            conn = http.client.HTTPConnection(f"{_KMS_PROXY_HOST}:{_KMS_PROXY_PORT}")
+        try:
+            conn.request(method, path)
+            return conn.getresponse().read().decode()
+        finally:
+            conn.close()
+
+    async def connect_count(self, tls=False):
+        body = await self.proxy_request("GET", "/metrics", tls=tls)
+        # The body is one "key value" pair per line. Only connect_count is
+        # required by the spec; the server also emits connect_target lines.
+        for line in body.splitlines():
+            key, _, value = line.partition(" ")
+            if key == "connect_count":
+                return int(value)
+        raise AssertionError(f"no connect_count in metrics body: {body!r}")
+
+    async def test_01_plain_http_proxy(self):
+        await self.proxy_request("POST", "/reset")
+        encryption = self.create_client_encryption(
+            {"aws": AWS_CREDS},
+            "keyvault.datakeys",
+            self.client,
+            OPTS,
+            kms_connect_callback=self.plain_callback,
+        )
+        await encryption.create_data_key("aws", master_key=_AWS_MASTER_KEY)
+        self.assertGreaterEqual(await self.connect_count(), 1)
+
+    async def test_02_https_proxy(self):
+        await self.proxy_request("POST", "/reset", tls=True)
+        encryption = self.create_client_encryption(
+            {"aws": AWS_CREDS},
+            "keyvault.datakeys",
+            self.client,
+            OPTS,
+            kms_connect_callback=self.tls_callback,
+        )
+        await encryption.create_data_key("aws", master_key=_AWS_MASTER_KEY)
+        self.assertGreaterEqual(await self.connect_count(tls=True), 1)
+
+    async def test_03_auto_encryption_through_proxy(self):
+        await self.client.keyvault.datakeys.drop()
+        await self.client.db.coll.drop()
+
+        encryption = self.create_client_encryption(
+            {"aws": AWS_CREDS},
+            "keyvault.datakeys",
+            self.client,
+            OPTS,
+            kms_connect_callback=self.plain_callback,
+        )
+        data_key_id = await encryption.create_data_key("aws", master_key=_AWS_MASTER_KEY)
+        schema = {
+            "bsonType": "object",
+            "properties": {
+                "encrypted_string": {
+                    "encrypt": {
+                        "keyId": [data_key_id],
+                        "bsonType": "string",
+                        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
+                    }
+                }
+            },
+        }
+
+        await self.proxy_request("POST", "/reset")
+        opts = AutoEncryptionOpts(
+            {"aws": AWS_CREDS},
+            "keyvault.datakeys",
+            schema_map={"db.coll": schema},
+            kms_connect_callback=self.plain_callback,
+        )
+        client_encrypted = await self.async_rs_or_single_client(auto_encryption_opts=opts)
+
+        await client_encrypted.db.coll.insert_one({"_id": 1, "encrypted_string": "hello"})
+        decrypted = await client_encrypted.db.coll.find_one({"_id": 1})
+        self.assertEqual(decrypted["encrypted_string"], "hello")
+
+        raw = await self.client.db.coll.find_one({"_id": 1})
+        self.assertIsInstance(raw["encrypted_string"], Binary)
+
+        self.assertGreaterEqual(await self.connect_count(), 1)
+
+    async def test_04_callback_error(self):
+        async def failing_callback(context):
+            raise OSError("proxy is on fire")
+
+        encryption = self.create_client_encryption(
+            {"aws": AWS_CREDS},
+            "keyvault.datakeys",
+            self.client,
+            OPTS,
+            kms_connect_callback=failing_callback,
+        )
+        with self.assertRaises(EncryptionError):
+            await encryption.create_data_key("aws", master_key=_AWS_MASTER_KEY)
+
+    async def test_05_callback_receives_timeout(self):
+        key_vault_client = await self.async_rs_or_single_client(timeoutMS=1000)
+        encryption = self.create_client_encryption(
+            {"aws": AWS_CREDS},
+            "keyvault.datakeys",
+            key_vault_client,
+            OPTS,
+            kms_connect_callback=self.plain_callback,
+        )
+        await encryption.create_data_key("aws", master_key=_AWS_MASTER_KEY)
+
+        self.assertTrue(self.callback_calls, "callback was never invoked")
+        for context in self.callback_calls:
+            self.assertIsNotNone(context.timeout)
+            self.assertGreater(context.timeout, 0)
+
+    async def test_06_retry_after_network_error(self):
+        state = {"calls": 0}
+
+        async def flaky_callback(context):
+            state["calls"] += 1
+            if state["calls"] == 1:
+                raise OSError("first attempt fails")
+            if not _IS_SYNC:
+                return await asyncio.to_thread(_http_connect, context, _KMS_PROXY_PORT)
+            return _http_connect(context, _KMS_PROXY_PORT)
+
+        encryption = self.create_client_encryption(
+            {"aws": AWS_CREDS},
+            "keyvault.datakeys",
+            self.client,
+            OPTS,
+            kms_connect_callback=flaky_callback,
+        )
+        await encryption.create_data_key("aws", master_key=_AWS_MASTER_KEY)
+        self.assertGreaterEqual(state["calls"], 2)
 
 
 # https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/tests/README.md#kms-tls-options-tests

--- a/test/asynchronous/test_pooling.py
+++ b/test/asynchronous/test_pooling.py
@@ -34,13 +34,19 @@ from pymongo.errors import AutoReconnect, ConnectionFailure, DuplicateKeyError
 from pymongo.hello import HelloCompat
 from pymongo.lock import _async_create_lock
 from pymongo.monitoring import _EventListeners
+from pymongo.pool_shared import _async_wrap_socket_tls
 from test.asynchronous.utils import async_get_pool, async_joinall, flaky
 
 sys.path[0:0] = [""]
 
 from pymongo.asynchronous.pool import Pool, PoolOptions
 from pymongo.socket_checker import SocketChecker
-from test.asynchronous import AsyncIntegrationTest, async_client_context, unittest
+from test.asynchronous import (
+    AsyncIntegrationTest,
+    AsyncPyMongoTestCase,
+    async_client_context,
+    unittest,
+)
 from test.asynchronous.helpers import ConcurrentRunner
 from test.utils_shared import CMAPListener, delay
 
@@ -757,6 +763,19 @@ class TestPoolHandleConnectionError(unittest.TestCase):
         err.__cause__ = ssl.SSLCertVerificationError("certificate verify failed")
         pool._handle_connection_error(err)
         self.assertFalse(err.has_error_label("SystemOverloadedError"))
+
+
+class TestWrapSocketTLS(AsyncPyMongoTestCase):
+    async def test_wrap_socket_tls_without_ssl_context_returns_same_socket(self):
+        options = PoolOptions(socket_timeout=7.5)
+        left, right = socket.socketpair()
+        self.addCleanup(left.close)
+        self.addCleanup(right.close)
+
+        result = await _async_wrap_socket_tls(left, ("kms.example.com", 443), options)
+
+        self.assertIs(result, left)
+        self.assertEqual(result.gettimeout(), 7.5)
 
 
 if __name__ == "__main__":

--- a/test/test_encryption.py
+++ b/test/test_encryption.py
@@ -62,7 +62,14 @@ from bson.json_util import JSONOptions
 from bson.son import SON
 from pymongo import ReadPreference
 from pymongo.cursor_shared import CursorType
-from pymongo.encryption_options import _HAVE_PYMONGOCRYPT, AutoEncryptionOpts, RangeOpts, TextOpts
+from pymongo.encryption_options import (
+    _HAVE_PYMONGOCRYPT,
+    AutoEncryptionOpts,
+    HTTPProxyKMSConnect,
+    KMSConnectContext,
+    RangeOpts,
+    TextOpts,
+)
 from pymongo.errors import (
     AutoReconnect,
     BulkWriteError,
@@ -348,6 +355,40 @@ class TestKmsConnectCallbackUnit(PyMongoTestCase):
 
         with self.assertRaisesRegex(ConfigurationError, "Streams, transports"):
             _connect_kms(("kms.example.com", 443), self._pool_options(), callback, 10.0)
+
+    def test_http_proxy_helper_tunnels_and_reports_refusal(self):
+        # Exercise the shipped helper against a stub proxy, so the CONNECT
+        # handshake is covered without KMS credentials.
+        accepted = []
+
+        def stub(listener, reply):
+            try:
+                conn, _ = listener.accept()
+            except OSError:
+                return
+            accepted.append(conn.recv(4096))
+            conn.sendall(reply)
+            conn.close()
+
+        def run_stub(reply):
+            listener = socket.socket()
+            listener.bind(("127.0.0.1", 0))
+            listener.listen(1)
+            self.addCleanup(listener.close)
+            threading.Thread(target=stub, args=(listener, reply), daemon=True).start()
+            return listener.getsockname()
+
+        host, port = run_stub(b"HTTP/1.1 200 Connection Established\r\n\r\n")
+        callback = HTTPProxyKMSConnect(host, port)
+        context = KMSConnectContext(host="kms.example.com", port=443, timeout=10)
+        sock = callback(context)
+        self.addCleanup(sock.close)
+        self.assertIsInstance(sock, socket.socket)
+        self.assertEqual(accepted[0].split(b"\r\n")[0], b"CONNECT kms.example.com:443 HTTP/1.1")
+
+        host, port = run_stub(b"HTTP/1.1 407 Proxy Authentication Required\r\n\r\n")
+        with self.assertRaisesRegex(OSError, "refused CONNECT"):
+            HTTPProxyKMSConnect(host, port)(context)
 
     def test_network_error_from_callback_propagates(self):
         def callback(context):
@@ -2103,60 +2144,6 @@ _AWS_MASTER_KEY = {
 }
 
 
-def _http_connect(context, proxy_port, proxy_ssl_context=None):
-    """Open an HTTP CONNECT tunnel to context.host:context.port.
-
-    Returns a plain socket. When proxy_ssl_context is given, the connection to
-    the proxy is TLS and the tunnel is bridged to a socketpair, because TLS
-    cannot be layered over an ssl.SSLSocket.
-    """
-    sock: socket.socket = socket.create_connection(
-        (_KMS_PROXY_HOST, proxy_port), timeout=context.timeout
-    )
-    try:
-        if proxy_ssl_context is not None:
-            sock = proxy_ssl_context.wrap_socket(sock, server_hostname=_KMS_PROXY_HOST)
-        target = f"{context.host}:{context.port}"
-        sock.sendall(f"CONNECT {target} HTTP/1.1\r\nHost: {target}\r\n\r\n".encode())
-        response = b""
-        while b"\r\n\r\n" not in response:
-            chunk = sock.recv(4096)
-            if not chunk:
-                raise OSError("proxy closed the connection before responding")
-            response += chunk
-        status = response.split(b"\r\n", 1)[0]
-        if not status.startswith(b"HTTP/1.1 200"):
-            raise OSError(f"proxy CONNECT failed: {status!r}")
-    except Exception:
-        sock.close()
-        raise
-
-    if proxy_ssl_context is None:
-        return sock
-
-    driver_side, relay_side = socket.socketpair()
-
-    def relay(src, dst):
-        try:
-            while True:
-                buf = src.recv(16384)
-                if not buf:
-                    break
-                dst.sendall(buf)
-        except OSError:
-            pass
-        finally:
-            for s in (src, dst):
-                try:
-                    s.close()
-                except OSError:
-                    pass
-
-    threading.Thread(target=relay, args=(relay_side, sock), daemon=True).start()
-    threading.Thread(target=relay, args=(sock, relay_side), daemon=True).start()
-    return driver_side
-
-
 # https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/tests/README.md#kms-connect-callback
 class TestKmsConnectCallbackProse(EncryptionIntegrationTest):
     @unittest.skipUnless(any(AWS_CREDS.values()), "AWS environment credentials are not set")
@@ -2166,17 +2153,14 @@ class TestKmsConnectCallbackProse(EncryptionIntegrationTest):
 
     def plain_callback(self, context):
         self.callback_calls.append(context)
-        if not _IS_SYNC:
-            return asyncio.to_thread(_http_connect, context, _KMS_PROXY_PORT)
-        return _http_connect(context, _KMS_PROXY_PORT)
+        return HTTPProxyKMSConnect(_KMS_PROXY_HOST, _KMS_PROXY_PORT)(context)
 
     def tls_callback(self, context):
         self.callback_calls.append(context)
         ctx = ssl.create_default_context(cafile=CA_PEM)
         ctx.check_hostname = False
-        if not _IS_SYNC:
-            return asyncio.to_thread(_http_connect, context, _KMS_TLS_PROXY_PORT, ctx)
-        return _http_connect(context, _KMS_TLS_PROXY_PORT, ctx)
+        callback = HTTPProxyKMSConnect(_KMS_PROXY_HOST, _KMS_TLS_PROXY_PORT, ctx)
+        return callback(context)
 
     def proxy_request(self, method, path, tls=False):
         """Call the proxy's control endpoints and return the body."""
@@ -2315,9 +2299,7 @@ class TestKmsConnectCallbackProse(EncryptionIntegrationTest):
             state["calls"] += 1
             if state["calls"] == 1:
                 raise OSError("first attempt fails")
-            if not _IS_SYNC:
-                return asyncio.to_thread(_http_connect, context, _KMS_PROXY_PORT)
-            return _http_connect(context, _KMS_PROXY_PORT)
+            return HTTPProxyKMSConnect(_KMS_PROXY_HOST, _KMS_PROXY_PORT)(context)
 
         encryption = self.create_client_encryption(
             {"aws": AWS_CREDS},

--- a/test/test_encryption.py
+++ b/test/test_encryption.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import base64
 import copy
+import dataclasses
 import http.client
 import json
 import os
@@ -212,6 +213,34 @@ class TestAutoEncryptionOpts(PyMongoTestCase):
         ctx = _kms_ssl_contexts["kmip"]
         self.assertEqual(ctx.check_hostname, True)
         self.assertEqual(ctx.verify_mode, ssl.CERT_REQUIRED)
+
+    @unittest.skipUnless(_HAVE_PYMONGOCRYPT, "pymongocrypt is not installed")
+    def test_init_kms_connect_callback(self):
+        from pymongo.encryption_options import KMSConnectContext
+
+        # Default is None.
+        opts = AutoEncryptionOpts({}, "k.d")
+        self.assertIsNone(opts._kms_connect_callback)
+
+        # A callable is accepted and stored unchanged.
+        def callback(context):
+            raise AssertionError("not called")
+
+        opts = AutoEncryptionOpts({}, "k.d", kms_connect_callback=callback)
+        self.assertIs(opts._kms_connect_callback, callback)
+
+        # Non-callables are rejected eagerly.
+        for bad in [1, "not-callable", object()]:
+            with self.assertRaisesRegex(TypeError, "kms_connect_callback must be callable"):
+                AutoEncryptionOpts({}, "k.d", kms_connect_callback=bad)  # type: ignore[arg-type]
+
+        # The context is frozen and carries host, port, and timeout.
+        context = KMSConnectContext(host="kms.example.com", port=443, timeout=9.5)
+        self.assertEqual(context.host, "kms.example.com")
+        self.assertEqual(context.port, 443)
+        self.assertEqual(context.timeout, 9.5)
+        with self.assertRaises(dataclasses.FrozenInstanceError):
+            context.host = "evil.example.com"  # type: ignore[misc]
 
 
 class TestClientOptions(PyMongoTestCase):

--- a/test/test_encryption.py
+++ b/test/test_encryption.py
@@ -75,8 +75,15 @@ from pymongo.errors import (
     WriteError,
 )
 from pymongo.operations import InsertOne, ReplaceOne, UpdateOne
+from pymongo.pool_options import PoolOptions
 from pymongo.synchronous import encryption
-from pymongo.synchronous.encryption import Algorithm, ClientEncryption, QueryType
+from pymongo.synchronous.encryption import (
+    Algorithm,
+    ClientEncryption,
+    QueryType,
+    _connect_kms,
+    _KMSCallbackContractError,
+)
 from pymongo.synchronous.helpers import next
 from pymongo.synchronous.mongo_client import MongoClient
 from pymongo.write_concern import WriteConcern
@@ -241,6 +248,70 @@ class TestAutoEncryptionOpts(PyMongoTestCase):
         self.assertEqual(context.timeout, 9.5)
         with self.assertRaises(dataclasses.FrozenInstanceError):
             context.host = "evil.example.com"  # type: ignore[misc]
+
+
+class TestKmsConnectCallbackUnit(PyMongoTestCase):
+    """Contract checks for kms_connect_callback that need no KMS server."""
+
+    @staticmethod
+    def _pool_options():
+        return PoolOptions(connect_timeout=10, socket_timeout=10, ssl_context=None)
+
+    def test_non_socket_return_is_not_retried(self):
+        def callback(context):
+            return "not-a-socket"
+
+        with self.assertRaisesRegex(_KMSCallbackContractError, "must return a connected"):
+            _connect_kms(("kms.example.com", 443), self._pool_options(), callback, 10.0)
+
+    def test_already_wrapped_socket_is_rejected(self):
+        # ssl.SSLSocket subclasses socket.socket, but wrap_socket cannot layer
+        # TLS over it, so it must be rejected with an actionable message rather
+        # than failing later with an opaque handshake error.
+        ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_NONE
+        left, right = socket.socketpair()
+        self.addCleanup(right.close)
+        # do_handshake_on_connect=False means no peer is needed to produce a
+        # genuine ssl.SSLSocket.
+        wrapped = ctx.wrap_socket(left, do_handshake_on_connect=False, server_hostname="x")
+        self.addCleanup(wrapped.close)
+
+        def callback(context):
+            return wrapped
+
+        with self.assertRaisesRegex(_KMSCallbackContractError, "unwrapped"):
+            _connect_kms(("kms.example.com", 443), self._pool_options(), callback, 10.0)
+
+    def test_context_receives_host_port_and_timeout(self):
+        received = []
+        left, right = socket.socketpair()
+        self.addCleanup(left.close)
+        self.addCleanup(right.close)
+
+        def callback(context):
+            received.append(context)
+            return left
+
+        # With ssl_context=None the socket is returned unchanged, which also
+        # confirms a plain socket is accepted.
+        conn = _connect_kms(("kms.example.com", 443), self._pool_options(), callback, 12.5)
+        self.assertIs(conn, left)
+
+        self.assertEqual(len(received), 1)
+        self.assertEqual(received[0].host, "kms.example.com")
+        self.assertEqual(received[0].port, 443)
+        self.assertEqual(received[0].timeout, 12.5)
+
+    def test_network_error_from_callback_propagates(self):
+        def callback(context):
+            raise OSError("proxy unreachable")
+
+        # Not wrapped in _KMSCallbackContractError, so kms_request's broad
+        # handler can treat it as transient and let libmongocrypt retry.
+        with self.assertRaises(OSError):
+            _connect_kms(("kms.example.com", 443), self._pool_options(), callback, 10.0)
 
 
 class TestClientOptions(PyMongoTestCase):

--- a/test/test_encryption.py
+++ b/test/test_encryption.py
@@ -341,6 +341,22 @@ class TestKmsConnectCallbackUnit(PyMongoTestCase):
         self.addCleanup(conn.close)
         self.assertIsNotNone(conn.gettimeout())
 
+    def test_asyncio_transport_socket_is_rejected(self):
+        # transport.get_extra_info("socket") returns an asyncio TransportSocket,
+        # not a socket.socket, and the loop still owns it. Reject it with a
+        # message that names the mistake rather than failing later.
+        from asyncio.trsock import TransportSocket
+
+        left, right = socket.socketpair()
+        self.addCleanup(left.close)
+        self.addCleanup(right.close)
+
+        def callback(context):
+            return TransportSocket(left)
+
+        with self.assertRaisesRegex(ConfigurationError, "asyncio stream or transport"):
+            _connect_kms(("kms.example.com", 443), self._pool_options(), callback, 10.0)
+
     def test_network_error_from_callback_propagates(self):
         def callback(context):
             raise OSError("proxy unreachable")

--- a/test/test_encryption.py
+++ b/test/test_encryption.py
@@ -227,23 +227,19 @@ class TestAutoEncryptionOpts(PyMongoTestCase):
     def test_init_kms_connect_callback(self):
         from pymongo.encryption_options import KMSConnectContext
 
-        # Default is None.
         opts = AutoEncryptionOpts({}, "k.d")
         self.assertIsNone(opts._kms_connect_callback)
 
-        # A callable is accepted and stored unchanged.
         def callback(context):
             raise AssertionError("not called")
 
         opts = AutoEncryptionOpts({}, "k.d", kms_connect_callback=callback)
         self.assertIs(opts._kms_connect_callback, callback)
 
-        # Non-callables are rejected eagerly.
         for bad in [1, "not-callable", object()]:
             with self.assertRaisesRegex(TypeError, "kms_connect_callback must be callable"):
                 AutoEncryptionOpts({}, "k.d", kms_connect_callback=bad)  # type: ignore[arg-type]
 
-        # The context is frozen and carries host, port, and timeout.
         context = KMSConnectContext(host="kms.example.com", port=443, timeout=9.5)
         self.assertEqual(context.host, "kms.example.com")
         self.assertEqual(context.port, 443)
@@ -268,8 +264,7 @@ class TestKmsConnectCallbackUnit(PyMongoTestCase):
 
     def test_already_wrapped_socket_is_rejected(self):
         # ssl.SSLSocket subclasses socket.socket, but wrap_socket cannot layer
-        # TLS over it, so it must be rejected with an actionable message rather
-        # than failing later with an opaque handshake error.
+        # TLS over it, so it needs its own rejection.
         ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
         ctx.check_hostname = False
         ctx.verify_mode = ssl.CERT_NONE
@@ -307,9 +302,8 @@ class TestKmsConnectCallbackUnit(PyMongoTestCase):
         self.assertEqual(received[0].timeout, 12.5)
 
     def test_non_blocking_socket_from_callback_is_accepted(self):
-        # ssl.SSLContext.wrap_socket refuses a non-blocking socket. The driver
-        # normalizes the mode so a callback need not care which mode it leaves
-        # the socket in. Without that, this handshake raises ValueError.
+        # wrap_socket refuses a non-blocking socket; the driver normalizes the
+        # mode. Without that, this handshake raises ValueError.
         server_ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
         server_ctx.load_cert_chain(CLIENT_PEM)
         listener = socket.socket()
@@ -326,9 +320,8 @@ class TestKmsConnectCallbackUnit(PyMongoTestCase):
 
         threading.Thread(target=serve, daemon=True).start()
 
-        # Build the context the way the driver does, so PoolOptions gets the
-        # flavor-correct type. Verification is off because the local test
-        # server's certificate is not what the driver would expect.
+        # Built the way the driver does, so PoolOptions gets the flavor-correct
+        # type. Verification is off: the local cert is not what it expects.
         client_ctx = get_ssl_context(None, None, None, None, True, True, False, _IS_SYNC)
         options = PoolOptions(connect_timeout=10, socket_timeout=10, ssl_context=client_ctx)
 
@@ -342,9 +335,8 @@ class TestKmsConnectCallbackUnit(PyMongoTestCase):
         self.assertIsNotNone(conn.gettimeout())
 
     def test_asyncio_transport_socket_is_rejected(self):
-        # transport.get_extra_info("socket") returns an asyncio TransportSocket,
-        # not a socket.socket, and the loop still owns it. Reject it with a
-        # message that names the mistake rather than failing later.
+        # transport.get_extra_info("socket") is an asyncio TransportSocket, not
+        # a socket.socket, and the loop still owns it.
         from asyncio.trsock import TransportSocket
 
         left, right = socket.socketpair()
@@ -354,7 +346,7 @@ class TestKmsConnectCallbackUnit(PyMongoTestCase):
         def callback(context):
             return TransportSocket(left)
 
-        with self.assertRaisesRegex(ConfigurationError, "asyncio stream or transport"):
+        with self.assertRaisesRegex(ConfigurationError, "Streams, transports"):
             _connect_kms(("kms.example.com", 443), self._pool_options(), callback, 10.0)
 
     def test_network_error_from_callback_propagates(self):

--- a/test/test_encryption.py
+++ b/test/test_encryption.py
@@ -270,15 +270,13 @@ class TestKmsConnectCallbackUnit(PyMongoTestCase):
             _connect_kms(("kms.example.com", 443), self._pool_options(), callback, 10.0)
 
     def test_already_wrapped_socket_is_rejected(self):
-        # ssl.SSLSocket subclasses socket.socket, but wrap_socket cannot layer
-        # TLS over it, so it needs its own rejection.
+        # ssl.SSLSocket passes isinstance but cannot be TLS-wrapped again.
         ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
         ctx.check_hostname = False
         ctx.verify_mode = ssl.CERT_NONE
         left, right = socket.socketpair()
         self.addCleanup(right.close)
-        # do_handshake_on_connect=False means no peer is needed to produce a
-        # genuine ssl.SSLSocket.
+        # No peer needed to produce a genuine ssl.SSLSocket.
         wrapped = ctx.wrap_socket(left, do_handshake_on_connect=False, server_hostname="x")
         self.addCleanup(wrapped.close)
 
@@ -298,7 +296,7 @@ class TestKmsConnectCallbackUnit(PyMongoTestCase):
             received.append(context)
             return left
 
-        # With ssl_context=None the socket is returned unchanged, which also
+        # ssl_context=None returns the socket unchanged, so this also
         # confirms a plain socket is accepted.
         conn = _connect_kms(("kms.example.com", 443), self._pool_options(), callback, 12.5)
         self.assertIs(conn, left)
@@ -309,8 +307,7 @@ class TestKmsConnectCallbackUnit(PyMongoTestCase):
         self.assertEqual(received[0].timeout, 12.5)
 
     def test_non_blocking_socket_from_callback_is_accepted(self):
-        # wrap_socket refuses a non-blocking socket; the driver normalizes the
-        # mode. Without that, this handshake raises ValueError.
+        # Without the driver normalizing the mode, this raises ValueError.
         server_ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
         server_ctx.load_cert_chain(CLIENT_PEM)
         listener = socket.socket()
@@ -327,8 +324,8 @@ class TestKmsConnectCallbackUnit(PyMongoTestCase):
 
         threading.Thread(target=serve, daemon=True).start()
 
-        # Built the way the driver does, so PoolOptions gets the flavor-correct
-        # type. Verification is off: the local cert is not what it expects.
+        # Built as the driver does, for the flavor-correct type; the local
+        # cert would not verify.
         client_ctx = get_ssl_context(None, None, None, None, True, True, False, _IS_SYNC)
         options = PoolOptions(connect_timeout=10, socket_timeout=10, ssl_context=client_ctx)
 
@@ -342,8 +339,7 @@ class TestKmsConnectCallbackUnit(PyMongoTestCase):
         self.assertIsNotNone(conn.gettimeout())
 
     def test_asyncio_transport_socket_is_rejected(self):
-        # transport.get_extra_info("socket") is an asyncio TransportSocket, not
-        # a socket.socket, and the loop still owns it.
+        # get_extra_info("socket") is a TransportSocket, not a socket.socket.
         from asyncio.trsock import TransportSocket
 
         left, right = socket.socketpair()
@@ -353,12 +349,11 @@ class TestKmsConnectCallbackUnit(PyMongoTestCase):
         def callback(context):
             return TransportSocket(left)
 
-        with self.assertRaisesRegex(ConfigurationError, "Streams, transports"):
+        with self.assertRaisesRegex(ConfigurationError, "TransportSocket"):
             _connect_kms(("kms.example.com", 443), self._pool_options(), callback, 10.0)
 
     def test_http_proxy_helper_tunnels_and_reports_refusal(self):
-        # Exercise the shipped helper against a stub proxy, so the CONNECT
-        # handshake is covered without KMS credentials.
+        # Covers the CONNECT handshake without KMS credentials.
         accepted = []
 
         def stub(listener, reply):
@@ -394,8 +389,7 @@ class TestKmsConnectCallbackUnit(PyMongoTestCase):
         def callback(context):
             raise OSError("proxy unreachable")
 
-        # Not a ConfigurationError, so kms_request's broad
-        # handler can treat it as transient and let libmongocrypt retry.
+        # Not a ConfigurationError, so kms_request retries it.
         with self.assertRaises(OSError):
             _connect_kms(("kms.example.com", 443), self._pool_options(), callback, 10.0)
 
@@ -2180,8 +2174,7 @@ class TestKmsConnectCallbackProse(EncryptionIntegrationTest):
 
     def connect_count(self, tls=False):
         body = self.proxy_request("GET", "/metrics", tls=tls)
-        # The body is one "key value" pair per line. Only connect_count is
-        # required by the spec; the server also emits connect_target lines.
+        # One "key value" per line; the server also emits connect_target.
         for line in body.splitlines():
             key, _, value = line.partition(" ")
             if key == "connect_count":
@@ -2286,9 +2279,7 @@ class TestKmsConnectCallbackProse(EncryptionIntegrationTest):
 
         self.assertTrue(self.callback_calls, "callback was never invoked")
         for context in self.callback_calls:
-            # Only checks the spec's literal non-zero requirement, which
-            # cannot fail: timeoutMS does not tighten this value because
-            # explicit ClientEncryption operations set no CSOT deadline.
+            # Checks only the spec's non-zero requirement, which cannot fail.
             self.assertIsNotNone(context.timeout)
             self.assertGreater(context.timeout, 0)
 

--- a/test/test_encryption.py
+++ b/test/test_encryption.py
@@ -2242,6 +2242,10 @@ class TestKmsConnectCallbackProse(EncryptionIntegrationTest):
         with self.assertRaisesRegex(EncryptionError, "proxy is on fire"):
             encryption.create_data_key("aws", master_key=_AWS_MASTER_KEY)
 
+    @unittest.skip(
+        "PYTHON-6037 ClientEncryption does not support timeoutMS, so the "
+        "callback always receives the default KMS connect timeout"
+    )
     def test_05_callback_receives_timeout(self):
         key_vault_client = self.rs_or_single_client(timeoutMS=1000)
         encryption = self.create_client_encryption(
@@ -2255,11 +2259,12 @@ class TestKmsConnectCallbackProse(EncryptionIntegrationTest):
 
         self.assertTrue(self.callback_calls, "callback was never invoked")
         for context in self.callback_calls:
-            # This only checks the spec's literal requirement (a non-zero
-            # timeout). timeoutMS=1000 above does not currently tighten this
-            # value: explicit ClientEncryption operations establish no CSOT
-            # deadline, so this always falls back to the driver's default KMS
-            # connect timeout regardless of key_vault_client's timeoutMS.
+            # Skipped: this would only check the spec's literal requirement
+            # (a non-zero timeout), which cannot fail here. timeoutMS=1000
+            # above does not tighten this value, because explicit
+            # ClientEncryption operations establish no CSOT deadline, so it
+            # always falls back to the driver's default KMS connect timeout.
+            # Un-skip once PYTHON-6037 adds timeoutMS to ClientEncryption.
             self.assertIsNotNone(context.timeout)
             self.assertGreater(context.timeout, 0)
 

--- a/test/test_encryption.py
+++ b/test/test_encryption.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import base64
 import copy
 import dataclasses
@@ -29,6 +30,7 @@ import socketserver
 import ssl
 import sys
 import textwrap
+import threading
 import traceback
 import uuid
 import warnings
@@ -2046,6 +2048,236 @@ class TestKmsTLSProse(EncryptionIntegrationTest):
             EncryptionError, "IP address mismatch|wronghost|IPAddressMismatch|Certificate"
         ):
             self.client_encrypted.create_data_key("aws", master_key=key)
+
+
+_KMS_PROXY_HOST = "127.0.0.1"
+_KMS_PROXY_PORT = 9004
+_KMS_TLS_PROXY_PORT = 9005
+
+_AWS_MASTER_KEY = {
+    "region": "us-east-1",
+    "key": "arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0",
+}
+
+
+def _http_connect(context, proxy_port, proxy_ssl_context=None):
+    """Open an HTTP CONNECT tunnel to context.host:context.port.
+
+    Returns a plain socket. When proxy_ssl_context is given, the connection to
+    the proxy is TLS and the tunnel is bridged to a socketpair, because TLS
+    cannot be layered over an ssl.SSLSocket.
+    """
+    sock: socket.socket = socket.create_connection(
+        (_KMS_PROXY_HOST, proxy_port), timeout=context.timeout
+    )
+    try:
+        if proxy_ssl_context is not None:
+            sock = proxy_ssl_context.wrap_socket(sock, server_hostname=_KMS_PROXY_HOST)
+        target = f"{context.host}:{context.port}"
+        sock.sendall(f"CONNECT {target} HTTP/1.1\r\nHost: {target}\r\n\r\n".encode())
+        response = b""
+        while b"\r\n\r\n" not in response:
+            chunk = sock.recv(4096)
+            if not chunk:
+                raise OSError("proxy closed the connection before responding")
+            response += chunk
+        status = response.split(b"\r\n", 1)[0]
+        if not status.startswith(b"HTTP/1.1 200"):
+            raise OSError(f"proxy CONNECT failed: {status!r}")
+    except Exception:
+        sock.close()
+        raise
+
+    if proxy_ssl_context is None:
+        return sock
+
+    driver_side, relay_side = socket.socketpair()
+
+    def relay(src, dst):
+        try:
+            while True:
+                buf = src.recv(16384)
+                if not buf:
+                    break
+                dst.sendall(buf)
+        except OSError:
+            pass
+        finally:
+            for s in (src, dst):
+                try:
+                    s.close()
+                except OSError:
+                    pass
+
+    threading.Thread(target=relay, args=(relay_side, sock), daemon=True).start()
+    threading.Thread(target=relay, args=(sock, relay_side), daemon=True).start()
+    return driver_side
+
+
+# https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/tests/README.md#kms-connect-callback
+class TestKmsConnectCallbackProse(EncryptionIntegrationTest):
+    @unittest.skipUnless(any(AWS_CREDS.values()), "AWS environment credentials are not set")
+    def setUp(self):
+        super().setUp()
+        self.callback_calls: list[Any] = []
+
+    def plain_callback(self, context):
+        self.callback_calls.append(context)
+        if not _IS_SYNC:
+            return asyncio.to_thread(_http_connect, context, _KMS_PROXY_PORT)
+        return _http_connect(context, _KMS_PROXY_PORT)
+
+    def tls_callback(self, context):
+        self.callback_calls.append(context)
+        ctx = ssl.create_default_context(cafile=CA_PEM)
+        ctx.check_hostname = False
+        if not _IS_SYNC:
+            return asyncio.to_thread(_http_connect, context, _KMS_TLS_PROXY_PORT, ctx)
+        return _http_connect(context, _KMS_TLS_PROXY_PORT, ctx)
+
+    def proxy_request(self, method, path, tls=False):
+        """Call the proxy's control endpoints and return the body."""
+        if tls:
+            ctx = ssl.create_default_context(cafile=CA_PEM)
+            ctx.check_hostname = False
+            conn = http.client.HTTPSConnection(
+                f"{_KMS_PROXY_HOST}:{_KMS_TLS_PROXY_PORT}", context=ctx
+            )
+        else:
+            conn = http.client.HTTPConnection(f"{_KMS_PROXY_HOST}:{_KMS_PROXY_PORT}")
+        try:
+            conn.request(method, path)
+            return conn.getresponse().read().decode()
+        finally:
+            conn.close()
+
+    def connect_count(self, tls=False):
+        body = self.proxy_request("GET", "/metrics", tls=tls)
+        # The body is one "key value" pair per line. Only connect_count is
+        # required by the spec; the server also emits connect_target lines.
+        for line in body.splitlines():
+            key, _, value = line.partition(" ")
+            if key == "connect_count":
+                return int(value)
+        raise AssertionError(f"no connect_count in metrics body: {body!r}")
+
+    def test_01_plain_http_proxy(self):
+        self.proxy_request("POST", "/reset")
+        encryption = self.create_client_encryption(
+            {"aws": AWS_CREDS},
+            "keyvault.datakeys",
+            self.client,
+            OPTS,
+            kms_connect_callback=self.plain_callback,
+        )
+        encryption.create_data_key("aws", master_key=_AWS_MASTER_KEY)
+        self.assertGreaterEqual(self.connect_count(), 1)
+
+    def test_02_https_proxy(self):
+        self.proxy_request("POST", "/reset", tls=True)
+        encryption = self.create_client_encryption(
+            {"aws": AWS_CREDS},
+            "keyvault.datakeys",
+            self.client,
+            OPTS,
+            kms_connect_callback=self.tls_callback,
+        )
+        encryption.create_data_key("aws", master_key=_AWS_MASTER_KEY)
+        self.assertGreaterEqual(self.connect_count(tls=True), 1)
+
+    def test_03_auto_encryption_through_proxy(self):
+        self.client.keyvault.datakeys.drop()
+        self.client.db.coll.drop()
+
+        encryption = self.create_client_encryption(
+            {"aws": AWS_CREDS},
+            "keyvault.datakeys",
+            self.client,
+            OPTS,
+            kms_connect_callback=self.plain_callback,
+        )
+        data_key_id = encryption.create_data_key("aws", master_key=_AWS_MASTER_KEY)
+        schema = {
+            "bsonType": "object",
+            "properties": {
+                "encrypted_string": {
+                    "encrypt": {
+                        "keyId": [data_key_id],
+                        "bsonType": "string",
+                        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
+                    }
+                }
+            },
+        }
+
+        self.proxy_request("POST", "/reset")
+        opts = AutoEncryptionOpts(
+            {"aws": AWS_CREDS},
+            "keyvault.datakeys",
+            schema_map={"db.coll": schema},
+            kms_connect_callback=self.plain_callback,
+        )
+        client_encrypted = self.rs_or_single_client(auto_encryption_opts=opts)
+
+        client_encrypted.db.coll.insert_one({"_id": 1, "encrypted_string": "hello"})
+        decrypted = client_encrypted.db.coll.find_one({"_id": 1})
+        self.assertEqual(decrypted["encrypted_string"], "hello")
+
+        raw = self.client.db.coll.find_one({"_id": 1})
+        self.assertIsInstance(raw["encrypted_string"], Binary)
+
+        self.assertGreaterEqual(self.connect_count(), 1)
+
+    def test_04_callback_error(self):
+        def failing_callback(context):
+            raise OSError("proxy is on fire")
+
+        encryption = self.create_client_encryption(
+            {"aws": AWS_CREDS},
+            "keyvault.datakeys",
+            self.client,
+            OPTS,
+            kms_connect_callback=failing_callback,
+        )
+        with self.assertRaises(EncryptionError):
+            encryption.create_data_key("aws", master_key=_AWS_MASTER_KEY)
+
+    def test_05_callback_receives_timeout(self):
+        key_vault_client = self.rs_or_single_client(timeoutMS=1000)
+        encryption = self.create_client_encryption(
+            {"aws": AWS_CREDS},
+            "keyvault.datakeys",
+            key_vault_client,
+            OPTS,
+            kms_connect_callback=self.plain_callback,
+        )
+        encryption.create_data_key("aws", master_key=_AWS_MASTER_KEY)
+
+        self.assertTrue(self.callback_calls, "callback was never invoked")
+        for context in self.callback_calls:
+            self.assertIsNotNone(context.timeout)
+            self.assertGreater(context.timeout, 0)
+
+    def test_06_retry_after_network_error(self):
+        state = {"calls": 0}
+
+        def flaky_callback(context):
+            state["calls"] += 1
+            if state["calls"] == 1:
+                raise OSError("first attempt fails")
+            if not _IS_SYNC:
+                return asyncio.to_thread(_http_connect, context, _KMS_PROXY_PORT)
+            return _http_connect(context, _KMS_PROXY_PORT)
+
+        encryption = self.create_client_encryption(
+            {"aws": AWS_CREDS},
+            "keyvault.datakeys",
+            self.client,
+            OPTS,
+            kms_connect_callback=flaky_callback,
+        )
+        encryption.create_data_key("aws", master_key=_AWS_MASTER_KEY)
+        self.assertGreaterEqual(state["calls"], 2)
 
 
 # https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/tests/README.md#kms-tls-options-tests

--- a/test/test_encryption.py
+++ b/test/test_encryption.py
@@ -295,8 +295,7 @@ class TestKmsConnectCallbackUnit(PyMongoTestCase):
             received.append(context)
             return left
 
-        # ssl_context=None returns the socket unchanged, so this also
-        # confirms a plain socket is accepted.
+        # ssl_context=None returns the socket unchanged, so a plain socket is accepted.
         conn = _connect_kms(("kms.example.com", 443), self._pool_options(), callback, 12.5)
         self.assertIs(conn, left)
 
@@ -323,8 +322,7 @@ class TestKmsConnectCallbackUnit(PyMongoTestCase):
 
         threading.Thread(target=serve, daemon=True).start()
 
-        # Built as the driver does, for the flavor-correct type; the local
-        # cert would not verify.
+        # Built as the driver does, for the flavor-correct type; the local cert won't verify.
         client_ctx = get_ssl_context(None, None, None, None, True, True, False, _IS_SYNC)
         options = PoolOptions(connect_timeout=10, socket_timeout=10, ssl_context=client_ctx)
 

--- a/test/test_encryption.py
+++ b/test/test_encryption.py
@@ -2259,12 +2259,9 @@ class TestKmsConnectCallbackProse(EncryptionIntegrationTest):
 
         self.assertTrue(self.callback_calls, "callback was never invoked")
         for context in self.callback_calls:
-            # Skipped: this would only check the spec's literal requirement
-            # (a non-zero timeout), which cannot fail here. timeoutMS=1000
-            # above does not tighten this value, because explicit
-            # ClientEncryption operations establish no CSOT deadline, so it
-            # always falls back to the driver's default KMS connect timeout.
-            # Un-skip once PYTHON-6037 adds timeoutMS to ClientEncryption.
+            # Only checks the spec's literal non-zero requirement, which
+            # cannot fail: timeoutMS does not tighten this value because
+            # explicit ClientEncryption operations set no CSOT deadline.
             self.assertIsNotNone(context.timeout)
             self.assertGreater(context.timeout, 0)
 

--- a/test/test_encryption.py
+++ b/test/test_encryption.py
@@ -84,7 +84,6 @@ from pymongo.synchronous.encryption import (
     ClientEncryption,
     QueryType,
     _connect_kms,
-    _KMSCallbackContractError,
 )
 from pymongo.synchronous.helpers import next
 from pymongo.synchronous.mongo_client import MongoClient
@@ -263,7 +262,7 @@ class TestKmsConnectCallbackUnit(PyMongoTestCase):
         def callback(context):
             return "not-a-socket"
 
-        with self.assertRaisesRegex(_KMSCallbackContractError, "must return a connected"):
+        with self.assertRaisesRegex(ConfigurationError, "must return a connected"):
             _connect_kms(("kms.example.com", 443), self._pool_options(), callback, 10.0)
 
     def test_already_wrapped_socket_is_rejected(self):
@@ -283,7 +282,7 @@ class TestKmsConnectCallbackUnit(PyMongoTestCase):
         def callback(context):
             return wrapped
 
-        with self.assertRaisesRegex(_KMSCallbackContractError, "unwrapped"):
+        with self.assertRaisesRegex(ConfigurationError, "unwrapped"):
             _connect_kms(("kms.example.com", 443), self._pool_options(), callback, 10.0)
 
     def test_context_receives_host_port_and_timeout(self):
@@ -310,7 +309,7 @@ class TestKmsConnectCallbackUnit(PyMongoTestCase):
         def callback(context):
             raise OSError("proxy unreachable")
 
-        # Not wrapped in _KMSCallbackContractError, so kms_request's broad
+        # Not a ConfigurationError, so kms_request's broad
         # handler can treat it as transient and let libmongocrypt retry.
         with self.assertRaises(OSError):
             _connect_kms(("kms.example.com", 443), self._pool_options(), callback, 10.0)

--- a/test/test_encryption.py
+++ b/test/test_encryption.py
@@ -78,6 +78,7 @@ from pymongo.errors import (
 )
 from pymongo.operations import InsertOne, ReplaceOne, UpdateOne
 from pymongo.pool_options import PoolOptions
+from pymongo.ssl_support import get_ssl_context
 from pymongo.synchronous import encryption
 from pymongo.synchronous.encryption import (
     Algorithm,
@@ -304,6 +305,41 @@ class TestKmsConnectCallbackUnit(PyMongoTestCase):
         self.assertEqual(received[0].host, "kms.example.com")
         self.assertEqual(received[0].port, 443)
         self.assertEqual(received[0].timeout, 12.5)
+
+    def test_non_blocking_socket_from_callback_is_accepted(self):
+        # ssl.SSLContext.wrap_socket refuses a non-blocking socket. The driver
+        # normalizes the mode so a callback need not care which mode it leaves
+        # the socket in. Without that, this handshake raises ValueError.
+        server_ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+        server_ctx.load_cert_chain(CLIENT_PEM)
+        listener = socket.socket()
+        listener.bind(("127.0.0.1", 0))
+        listener.listen(1)
+        self.addCleanup(listener.close)
+
+        def serve():
+            try:
+                conn, _ = listener.accept()
+                server_ctx.wrap_socket(conn, server_side=True).close()
+            except OSError:
+                pass
+
+        threading.Thread(target=serve, daemon=True).start()
+
+        # Build the context the way the driver does, so PoolOptions gets the
+        # flavor-correct type. Verification is off because the local test
+        # server's certificate is not what the driver would expect.
+        client_ctx = get_ssl_context(None, None, None, None, True, True, False, _IS_SYNC)
+        options = PoolOptions(connect_timeout=10, socket_timeout=10, ssl_context=client_ctx)
+
+        def callback(context):
+            sock = socket.create_connection(listener.getsockname(), timeout=10)
+            sock.setblocking(False)
+            return sock
+
+        conn = _connect_kms(listener.getsockname(), options, callback, 10.0)
+        self.addCleanup(conn.close)
+        self.assertIsNotNone(conn.gettimeout())
 
     def test_network_error_from_callback_propagates(self):
         def callback(context):

--- a/test/test_encryption.py
+++ b/test/test_encryption.py
@@ -313,6 +313,34 @@ class TestKmsConnectCallbackUnit(PyMongoTestCase):
         with self.assertRaises(OSError):
             _connect_kms(("kms.example.com", 443), self._pool_options(), callback, 10.0)
 
+    @unittest.skipUnless(_HAVE_PYMONGOCRYPT, "pymongocrypt is not installed")
+    def test_client_encryption_accepts_callback(self):
+        def callback(context):
+            raise AssertionError("not called")
+
+        client = self.simple_client()
+        encryption = ClientEncryption(
+            {"local": {"key": b"\x00" * 96}},
+            "keyvault.datakeys",
+            client,
+            OPTS,
+            kms_connect_callback=callback,
+        )
+        self.addCleanup(encryption.close)
+        self.assertIs(encryption._io_callbacks.opts._kms_connect_callback, callback)
+
+    @unittest.skipUnless(_HAVE_PYMONGOCRYPT, "pymongocrypt is not installed")
+    def test_client_encryption_rejects_non_callable(self):
+        client = self.simple_client()
+        with self.assertRaisesRegex(TypeError, "kms_connect_callback must be callable"):
+            ClientEncryption(
+                {"local": {"key": b"\x00" * 96}},
+                "keyvault.datakeys",
+                client,
+                OPTS,
+                kms_connect_callback="not-callable",  # type: ignore[arg-type]
+            )
+
 
 class TestClientOptions(PyMongoTestCase):
     def test_default(self):
@@ -352,9 +380,15 @@ class EncryptionIntegrationTest(IntegrationTest):
         key_vault_client: MongoClient,
         codec_options: CodecOptions,
         kms_tls_options: Optional[Mapping[str, Any]] = None,
+        kms_connect_callback: Optional[Any] = None,
     ):
         client_encryption = ClientEncryption(
-            kms_providers, key_vault_namespace, key_vault_client, codec_options, kms_tls_options
+            kms_providers,
+            key_vault_namespace,
+            key_vault_client,
+            codec_options,
+            kms_tls_options,
+            kms_connect_callback=kms_connect_callback,
         )
         self.addCleanup(client_encryption.close)
         return client_encryption
@@ -367,9 +401,15 @@ class EncryptionIntegrationTest(IntegrationTest):
         key_vault_client: MongoClient,
         codec_options: CodecOptions,
         kms_tls_options: Optional[Mapping[str, Any]] = None,
+        kms_connect_callback: Optional[Any] = None,
     ):
         client_encryption = ClientEncryption(
-            kms_providers, key_vault_namespace, key_vault_client, codec_options, kms_tls_options
+            kms_providers,
+            key_vault_namespace,
+            key_vault_client,
+            codec_options,
+            kms_tls_options,
+            kms_connect_callback=kms_connect_callback,
         )
         return client_encryption
 

--- a/test/test_encryption.py
+++ b/test/test_encryption.py
@@ -2239,7 +2239,7 @@ class TestKmsConnectCallbackProse(EncryptionIntegrationTest):
             OPTS,
             kms_connect_callback=failing_callback,
         )
-        with self.assertRaises(EncryptionError):
+        with self.assertRaisesRegex(EncryptionError, "proxy is on fire"):
             encryption.create_data_key("aws", master_key=_AWS_MASTER_KEY)
 
     def test_05_callback_receives_timeout(self):

--- a/test/test_encryption.py
+++ b/test/test_encryption.py
@@ -2255,6 +2255,11 @@ class TestKmsConnectCallbackProse(EncryptionIntegrationTest):
 
         self.assertTrue(self.callback_calls, "callback was never invoked")
         for context in self.callback_calls:
+            # This only checks the spec's literal requirement (a non-zero
+            # timeout). timeoutMS=1000 above does not currently tighten this
+            # value: explicit ClientEncryption operations establish no CSOT
+            # deadline, so this always falls back to the driver's default KMS
+            # connect timeout regardless of key_vault_client's timeoutMS.
             self.assertIsNotNone(context.timeout)
             self.assertGreater(context.timeout, 0)
 

--- a/test/test_encryption.py
+++ b/test/test_encryption.py
@@ -2125,11 +2125,11 @@ class TestKmsTLSProse(EncryptionIntegrationTest):
             self.client_encrypted.create_data_key("aws", master_key=key)
 
 
-_KMS_PROXY_HOST = "127.0.0.1"
-_KMS_PROXY_PORT = 9004
-_KMS_TLS_PROXY_PORT = 9005
+KMS_PROXY_HOST = "127.0.0.1"
+KMS_PROXY_PORT = 9004
+KMS_TLS_PROXY_PORT = 9005
 
-_AWS_MASTER_KEY = {
+AWS_MASTER_KEY = {
     "region": "us-east-1",
     "key": "arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0",
 }
@@ -2144,13 +2144,13 @@ class TestKmsConnectCallbackProse(EncryptionIntegrationTest):
 
     def plain_callback(self, context):
         self.callback_calls.append(context)
-        return HTTPProxyKMSConnect(_KMS_PROXY_HOST, _KMS_PROXY_PORT)(context)
+        return HTTPProxyKMSConnect(KMS_PROXY_HOST, KMS_PROXY_PORT)(context)
 
     def tls_callback(self, context):
         self.callback_calls.append(context)
         ctx = ssl.create_default_context(cafile=CA_PEM)
         ctx.check_hostname = False
-        callback = HTTPProxyKMSConnect(_KMS_PROXY_HOST, _KMS_TLS_PROXY_PORT, ctx)
+        callback = HTTPProxyKMSConnect(KMS_PROXY_HOST, KMS_TLS_PROXY_PORT, ctx)
         return callback(context)
 
     def proxy_request(self, method, path, tls=False):
@@ -2159,10 +2159,10 @@ class TestKmsConnectCallbackProse(EncryptionIntegrationTest):
             ctx = ssl.create_default_context(cafile=CA_PEM)
             ctx.check_hostname = False
             conn = http.client.HTTPSConnection(
-                f"{_KMS_PROXY_HOST}:{_KMS_TLS_PROXY_PORT}", context=ctx
+                f"{KMS_PROXY_HOST}:{KMS_TLS_PROXY_PORT}", context=ctx
             )
         else:
-            conn = http.client.HTTPConnection(f"{_KMS_PROXY_HOST}:{_KMS_PROXY_PORT}")
+            conn = http.client.HTTPConnection(f"{KMS_PROXY_HOST}:{KMS_PROXY_PORT}")
         try:
             conn.request(method, path)
             return conn.getresponse().read().decode()
@@ -2187,7 +2187,7 @@ class TestKmsConnectCallbackProse(EncryptionIntegrationTest):
             OPTS,
             kms_connect_callback=self.plain_callback,
         )
-        encryption.create_data_key("aws", master_key=_AWS_MASTER_KEY)
+        encryption.create_data_key("aws", master_key=AWS_MASTER_KEY)
         self.assertGreaterEqual(self.connect_count(), 1)
 
     def test_02_https_proxy(self):
@@ -2199,7 +2199,7 @@ class TestKmsConnectCallbackProse(EncryptionIntegrationTest):
             OPTS,
             kms_connect_callback=self.tls_callback,
         )
-        encryption.create_data_key("aws", master_key=_AWS_MASTER_KEY)
+        encryption.create_data_key("aws", master_key=AWS_MASTER_KEY)
         self.assertGreaterEqual(self.connect_count(tls=True), 1)
 
     def test_03_auto_encryption_through_proxy(self):
@@ -2213,7 +2213,7 @@ class TestKmsConnectCallbackProse(EncryptionIntegrationTest):
             OPTS,
             kms_connect_callback=self.plain_callback,
         )
-        data_key_id = encryption.create_data_key("aws", master_key=_AWS_MASTER_KEY)
+        data_key_id = encryption.create_data_key("aws", master_key=AWS_MASTER_KEY)
         schema = {
             "bsonType": "object",
             "properties": {
@@ -2257,7 +2257,7 @@ class TestKmsConnectCallbackProse(EncryptionIntegrationTest):
             kms_connect_callback=failing_callback,
         )
         with self.assertRaisesRegex(EncryptionError, "proxy is on fire"):
-            encryption.create_data_key("aws", master_key=_AWS_MASTER_KEY)
+            encryption.create_data_key("aws", master_key=AWS_MASTER_KEY)
 
     @unittest.skip(
         "PYTHON-6037 ClientEncryption does not support timeoutMS, so the "
@@ -2272,7 +2272,7 @@ class TestKmsConnectCallbackProse(EncryptionIntegrationTest):
             OPTS,
             kms_connect_callback=self.plain_callback,
         )
-        encryption.create_data_key("aws", master_key=_AWS_MASTER_KEY)
+        encryption.create_data_key("aws", master_key=AWS_MASTER_KEY)
 
         self.assertTrue(self.callback_calls, "callback was never invoked")
         for context in self.callback_calls:
@@ -2287,7 +2287,7 @@ class TestKmsConnectCallbackProse(EncryptionIntegrationTest):
             state["calls"] += 1
             if state["calls"] == 1:
                 raise OSError("first attempt fails")
-            return HTTPProxyKMSConnect(_KMS_PROXY_HOST, _KMS_PROXY_PORT)(context)
+            return HTTPProxyKMSConnect(KMS_PROXY_HOST, KMS_PROXY_PORT)(context)
 
         encryption = self.create_client_encryption(
             {"aws": AWS_CREDS},
@@ -2296,7 +2296,7 @@ class TestKmsConnectCallbackProse(EncryptionIntegrationTest):
             OPTS,
             kms_connect_callback=flaky_callback,
         )
-        encryption.create_data_key("aws", master_key=_AWS_MASTER_KEY)
+        encryption.create_data_key("aws", master_key=AWS_MASTER_KEY)
         self.assertGreaterEqual(state["calls"], 2)
 
 

--- a/test/test_encryption.py
+++ b/test/test_encryption.py
@@ -34,6 +34,7 @@ import threading
 import traceback
 import uuid
 import warnings
+from asyncio.trsock import TransportSocket
 from collections.abc import Mapping
 from threading import Thread
 from typing import Any, Optional
@@ -232,8 +233,6 @@ class TestAutoEncryptionOpts(PyMongoTestCase):
 
     @unittest.skipUnless(_HAVE_PYMONGOCRYPT, "pymongocrypt is not installed")
     def test_init_kms_connect_callback(self):
-        from pymongo.encryption_options import KMSConnectContext
-
         opts = AutoEncryptionOpts({}, "k.d")
         self.assertIsNone(opts._kms_connect_callback)
 
@@ -340,8 +339,6 @@ class TestKmsConnectCallbackUnit(PyMongoTestCase):
 
     def test_asyncio_transport_socket_is_rejected(self):
         # get_extra_info("socket") is a TransportSocket, not a socket.socket.
-        from asyncio.trsock import TransportSocket
-
         left, right = socket.socketpair()
         self.addCleanup(left.close)
         self.addCleanup(right.close)

--- a/test/test_pooling.py
+++ b/test/test_pooling.py
@@ -34,13 +34,19 @@ from pymongo.errors import AutoReconnect, ConnectionFailure, DuplicateKeyError
 from pymongo.hello import HelloCompat
 from pymongo.lock import _create_lock
 from pymongo.monitoring import _EventListeners
+from pymongo.pool_shared import _wrap_socket_tls
 from test.utils import flaky, get_pool, joinall
 
 sys.path[0:0] = [""]
 
 from pymongo.socket_checker import SocketChecker
 from pymongo.synchronous.pool import Pool, PoolOptions
-from test import IntegrationTest, client_context, unittest
+from test import (
+    IntegrationTest,
+    PyMongoTestCase,
+    client_context,
+    unittest,
+)
 from test.helpers import ConcurrentRunner
 from test.utils_shared import CMAPListener, delay
 
@@ -755,6 +761,19 @@ class TestPoolHandleConnectionError(unittest.TestCase):
         err.__cause__ = ssl.SSLCertVerificationError("certificate verify failed")
         pool._handle_connection_error(err)
         self.assertFalse(err.has_error_label("SystemOverloadedError"))
+
+
+class TestWrapSocketTLS(PyMongoTestCase):
+    def test_wrap_socket_tls_without_ssl_context_returns_same_socket(self):
+        options = PoolOptions(socket_timeout=7.5)
+        left, right = socket.socketpair()
+        self.addCleanup(left.close)
+        self.addCleanup(right.close)
+
+        result = _wrap_socket_tls(left, ("kms.example.com", 443), options)
+
+        self.assertIs(result, left)
+        self.assertEqual(result.gettimeout(), 7.5)
 
 
 if __name__ == "__main__":

--- a/tools/synchro.py
+++ b/tools/synchro.py
@@ -143,11 +143,6 @@ replacements = {
     "dns.asyncresolver.resolve": "dns.resolver.resolve",
     "__aenter__": "__enter__",
     "__aexit__": "__exit__",
-    # Prose substitution, not an identifier/token like the rest of this dict. Matching is
-    # line-based (see translate_docstrings), so this sentence must stay on a single line in
-    # pymongo/asynchronous/encryption.py or the replacement silently stops firing. Guarded by
-    # check_kms_connect_callback_docstring(), called from main() below.
-    "Must be a coroutine function.": "Must be a regular function.",
 }
 
 docstring_replacements: dict[tuple[str, str], str] = {
@@ -340,37 +335,6 @@ def process_ignores(lines: list[str]) -> list[str]:
     return lines
 
 
-def check_kms_connect_callback_docstring() -> None:
-    """Guard the "Must be a coroutine function." -> "Must be a regular function." mapping.
-
-    That replacement in `replacements` above only fires if the sentence sits on a single
-    line in the async source (see translate_docstrings). A future edit or re-wrap could
-    silently break the match, leaving the generated synchronous docs telling users to write
-    an `async def` callback. Fail loudly instead of leaving that undetected.
-    """
-    sync_encryption = Path(_pymongo_dest_base) / "encryption.py"
-    if not sync_encryption.is_file():
-        # Nothing to check yet, e.g. a partial/filtered run that didn't touch this file.
-        return
-    content = sync_encryption.read_text()
-    if "Must be a coroutine function." in content:
-        raise RuntimeError(
-            f"{sync_encryption} still says 'Must be a coroutine function.' after synchro. "
-            "The 'Must be a coroutine function.' -> 'Must be a regular function.' entry in "
-            "tools/synchro.py's `replacements` dict didn't fire, most likely because the "
-            "sentence in pymongo/asynchronous/encryption.py got wrapped across multiple "
-            "lines. Keep it on one line, or fix the replacement mapping."
-        )
-    if "kms_connect_callback" in content and "Must be a regular function." not in content:
-        raise RuntimeError(
-            f"{sync_encryption} defines kms_connect_callback but its docstring no longer "
-            "says 'Must be a regular function.'. Check that the "
-            "'Must be a coroutine function.' -> 'Must be a regular function.' entry is still "
-            "present in tools/synchro.py's `replacements` dict and that the docstring wording "
-            "in pymongo/asynchronous/encryption.py hasn't changed out from under it."
-        )
-
-
 def unasync_directory(files: list[str], src: str, dest: str, replacements: dict[str, str]) -> None:
     unasync_files(
         files,
@@ -438,8 +402,6 @@ def main() -> None:
         docstring_translate_files,
         generated_tests,
     )
-
-    check_kms_connect_callback_docstring()
 
     generated_files = generated_pymongo + generated_gridfs + generated_tests
 

--- a/tools/synchro.py
+++ b/tools/synchro.py
@@ -143,6 +143,7 @@ replacements = {
     "dns.asyncresolver.resolve": "dns.resolver.resolve",
     "__aenter__": "__enter__",
     "__aexit__": "__exit__",
+    "Must be a coroutine function.": "Must be a regular function.",
 }
 
 docstring_replacements: dict[tuple[str, str], str] = {

--- a/tools/synchro.py
+++ b/tools/synchro.py
@@ -143,6 +143,10 @@ replacements = {
     "dns.asyncresolver.resolve": "dns.resolver.resolve",
     "__aenter__": "__enter__",
     "__aexit__": "__exit__",
+    # Prose substitution, not an identifier/token like the rest of this dict. Matching is
+    # line-based (see translate_docstrings), so this sentence must stay on a single line in
+    # pymongo/asynchronous/encryption.py or the replacement silently stops firing. Guarded by
+    # check_kms_connect_callback_docstring(), called from main() below.
     "Must be a coroutine function.": "Must be a regular function.",
 }
 
@@ -336,6 +340,37 @@ def process_ignores(lines: list[str]) -> list[str]:
     return lines
 
 
+def check_kms_connect_callback_docstring() -> None:
+    """Guard the "Must be a coroutine function." -> "Must be a regular function." mapping.
+
+    That replacement in `replacements` above only fires if the sentence sits on a single
+    line in the async source (see translate_docstrings). A future edit or re-wrap could
+    silently break the match, leaving the generated synchronous docs telling users to write
+    an `async def` callback. Fail loudly instead of leaving that undetected.
+    """
+    sync_encryption = Path(_pymongo_dest_base) / "encryption.py"
+    if not sync_encryption.is_file():
+        # Nothing to check yet, e.g. a partial/filtered run that didn't touch this file.
+        return
+    content = sync_encryption.read_text()
+    if "Must be a coroutine function." in content:
+        raise RuntimeError(
+            f"{sync_encryption} still says 'Must be a coroutine function.' after synchro. "
+            "The 'Must be a coroutine function.' -> 'Must be a regular function.' entry in "
+            "tools/synchro.py's `replacements` dict didn't fire, most likely because the "
+            "sentence in pymongo/asynchronous/encryption.py got wrapped across multiple "
+            "lines. Keep it on one line, or fix the replacement mapping."
+        )
+    if "kms_connect_callback" in content and "Must be a regular function." not in content:
+        raise RuntimeError(
+            f"{sync_encryption} defines kms_connect_callback but its docstring no longer "
+            "says 'Must be a regular function.'. Check that the "
+            "'Must be a coroutine function.' -> 'Must be a regular function.' entry is still "
+            "present in tools/synchro.py's `replacements` dict and that the docstring wording "
+            "in pymongo/asynchronous/encryption.py hasn't changed out from under it."
+        )
+
+
 def unasync_directory(files: list[str], src: str, dest: str, replacements: dict[str, str]) -> None:
     unasync_files(
         files,
@@ -403,6 +438,8 @@ def main() -> None:
         docstring_translate_files,
         generated_tests,
     )
+
+    check_kms_connect_callback_docstring()
 
     generated_files = generated_pymongo + generated_gridfs + generated_tests
 

--- a/tools/synchro.py
+++ b/tools/synchro.py
@@ -127,6 +127,7 @@ replacements = {
     "AsyncNetworkingInterface": "NetworkingInterface",
     "_configured_protocol_interface": "_configured_socket_interface",
     "_async_configured_socket": "_configured_socket",
+    "_async_wrap_socket_tls": "_wrap_socket_tls",
     "SpecRunnerTask": "SpecRunnerThread",
     "AsyncMockConnection": "MockConnection",
     "AsyncMockPool": "MockPool",

--- a/tools/synchro.py
+++ b/tools/synchro.py
@@ -72,6 +72,7 @@ replacements = {
     "_a_grid_out_property": "_grid_out_property",
     "AsyncClientEncryption": "ClientEncryption",
     "AsyncMongoCryptCallback": "MongoCryptCallback",
+    "AsyncKMSConnectCallback": "KMSConnectCallback",
     "AsyncExplicitEncrypter": "ExplicitEncrypter",
     "AsyncAutoEncrypter": "AutoEncrypter",
     "AsyncContextManager": "ContextManager",

--- a/tools/synchro.py
+++ b/tools/synchro.py
@@ -73,6 +73,7 @@ replacements = {
     "AsyncClientEncryption": "ClientEncryption",
     "AsyncMongoCryptCallback": "MongoCryptCallback",
     "AsyncKMSConnectCallback": "KMSConnectCallback",
+    "AsyncHTTPProxyKMSConnect": "HTTPProxyKMSConnect",
     "AsyncExplicitEncrypter": "ExplicitEncrypter",
     "AsyncAutoEncrypter": "AutoEncrypter",
     "AsyncContextManager": "ContextManager",


### PR DESCRIPTION
PYTHON-5805

## Changes in this PR

Lets CSFLE and Queryable Encryption tunnel KMS traffic through an HTTP proxy, which networks that force outbound 443 through a proxy currently make impossible. The caller opens the connection and the driver still performs the KMS TLS handshake, so verification targets the KMS host rather than the proxy.

- Adds `kms_connect_callback` on `AutoEncryptionOpts`, `ClientEncryption` and `AsyncClientEncryption`, plus `KMSConnectContext`.
- Adds `HTTPProxyKMSConnect` and `AsyncHTTPProxyKMSConnect`, so most users pass a helper instead of writing a callback.
- Splits TLS wrapping out of the connect helpers in `pymongo/pool_shared.py`, leaving existing connection paths unchanged.
- Raises `ConfigurationError`, without retrying, when a callback returns the wrong thing; network errors stay retryable.
- Adds the six prose tests from section 28 of the client-side-encryption test specification.
- Skips prose case 5 as a known specification discrepancy, tracked in PYTHON-6037.

Mostly tests: 804 of the 1222 added lines, half of them the synchro-generated mirror.

## Test Plan

Prose tests against real AWS KMS through the drivers-evergreen-tools proxies, both flavors: 10 passed, 2 skipped, 0 failed. The proxy logged `connect_target kms.us-east-1.amazonaws.com:443`. Unit tests: 18 passed. `just lint`, `just typing` and `just docs` clean.

Evergreen patch, 7 encryption variants across RHEL8, macOS and Windows: https://spruce.corp.mongodb.com/version/6a873cdeb7e195000786c854

## Checklist

### Checklist for Author
- [x] Did you update the changelog (if necessary)?
- [x] Is there test coverage?
- [x] Is any followup work tracked in a JIRA ticket? If so, add link(s).
  - PYTHON-6037 Support timeoutMS on ClientEncryption

### Checklist for Reviewer
- [ ] Does the title of the PR reference a JIRA Ticket?
- [ ] Do you fully understand the implementation? (Would you be comfortable explaining how this code works to someone else?)
- [ ] Is all relevant documentation (README or docstring) updated?
